### PR TITLE
Minimize dependencies

### DIFF
--- a/java/build/bazel/tests/integration/BUILD
+++ b/java/build/bazel/tests/integration/BUILD
@@ -5,6 +5,11 @@ java_library(
     srcs = ["WorkspaceDriver.java",
             "Command.java",
             "LineListOutputStream.java",],
+    data = [
+        "@build_bazel_bazel_%s//:bazel" % v.replace(".", "_")
+        for v in BAZEL_VERSIONS
+    ],
+    testonly = True,
     visibility = ["//visibility:public"]
 )
 
@@ -12,10 +17,6 @@ java_library(
     name = "integration",
     srcs = [
         "BazelBaseTestCase.java",
-    ],
-    data = [
-        "@build_bazel_bazel_%s//:bazel" % v.replace(".", "_")
-        for v in BAZEL_VERSIONS
     ],
     deps = [
         ":workspace_driver",

--- a/java/build/bazel/tests/integration/BUILD
+++ b/java/build/bazel/tests/integration/BUILD
@@ -5,10 +5,6 @@ java_library(
     srcs = ["WorkspaceDriver.java",
             "Command.java",
             "LineListOutputStream.java",],
-    data = [
-        "@build_bazel_bazel_%s//:bazel" % v.replace(".", "_")
-        for v in BAZEL_VERSIONS
-    ],
     testonly = True,
     visibility = ["//visibility:public"]
 )

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -6,7 +6,7 @@ bazel_java_integration_test(
     data = [
         "//:all_bzl",
     ],
-    deps = ["//java/build/bazel/tests/integration:workspace_driver",
+    deps = ["//java/build/bazel/tests/integration",
             "@com_google_truth//jar",
             "@com_spotify_hamcrest_optional//jar"],
 )

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -169,20 +169,18 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
   private void loadIntegrationTestRuleIntoWorkspace() throws IOException {
     setupRuleSkylarkFiles();
     setupRuleCode();
-    addExternalRepositoryFor("org_junit", "junit-4.11.jar");
-    addExternalRepositoryFor("org_hamcrest_core", "hamcrest-core-1.3.jar");
-    writeWorkspaceFileWithRepositories("org_junit", "org_hamcrest_core");
+    scratchFile("./WORKSPACE",WORKSPACE_NAME);
   }
 
   private void setupRuleCode() throws IOException {
     copyFromRunfiles(
-        "build_bazel_integration_testing/java/build/bazel/tests/integration/libintegration.jar",
-        "java/build/bazel/tests/integration/libintegration.jar");
+        "build_bazel_integration_testing/java/build/bazel/tests/integration/libworkspace_driver.jar",
+        "java/build/bazel/tests/integration/libworkspace_driver.jar");
     scratchFile(
         "java/build/bazel/tests/integration/BUILD.bazel",
         "java_import(",
-        "    name = 'integration',",
-        "    jars = ['libintegration.jar'],",
+        "    name = 'workspace_driver',",
+        "    jars = ['libworkspace_driver.jar'],",
         "    visibility = ['//visibility:public']",
         ")");
   }
@@ -210,46 +208,6 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
             + "  pass");
     // In order to make //go a package it must have a build file (even if it's empty).
     scratchFile("go/BUILD.bazel", "");
-  }
-
-  private void writeWorkspaceFileWithRepositories(
-      final String junitRepoName, final String hamcrestRepoName) throws IOException {
-    scratchFile(
-        "./WORKSPACE",
-        aggregate(
-            WORKSPACE_NAME,
-            repositoryDeclarationFor(junitRepoName),
-            repositoryDeclarationFor(hamcrestRepoName)));
-  }
-
-  private List<String> aggregate(
-      final String workspaceName, final Stream<String> repo1, final Stream<String> repo2) {
-    return Stream.of(Stream.of(workspaceName), repo1, repo2)
-        .flatMap(s -> s)
-        .collect(Collectors.toList());
-  }
-
-  private Stream<String> repositoryDeclarationFor(final String repoName) {
-    return Stream.of(
-        "local_repository(",
-        "    name = '" + repoName + "',",
-        "    path = './external/" + repoName + "'",
-        ")");
-  }
-
-  private void addExternalRepositoryFor(final String repoName, final String repoJarName)
-      throws IOException {
-    copyFromRunfiles(
-        "build_bazel_integration_testing/external/" + repoName + "/jar/" + repoJarName,
-        "external/" + repoName + "/jar/" + repoJarName);
-    scratchFile("external/" + repoName + "/WORKSPACE", "");
-    scratchFile(
-        "external/" + repoName + "/jar/BUILD.bazel",
-        "java_import(",
-        "    name = 'jar',",
-        "    jars = ['" + repoJarName + "'],",
-        "    visibility = ['//visibility:public']",
-        ")");
   }
 
   private void writePassingTestJavaSource(final String testName) throws IOException {

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -163,8 +163,8 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
         "    name = '" + testName + "',",
         "    test_class = '" + testName + "',",
         "    srcs = ['" + testName + ".java'],",
-        //inside the sandbox we don't have access to full bazel
-        //and we don't need it since it's prepared in advance for us
+        // inside the sandbox we don't have access to full bazel
+        // and we don't need it since it's prepared in advance for us
         "    add_bazel_data_dependency = False,",
         ")");
   }

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -163,6 +163,9 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
         "    name = '" + testName + "',",
         "    test_class = '" + testName + "',",
         "    srcs = ['" + testName + ".java'],",
+        //inside the sandbox we don't have access to full bazel
+        //and we don't need it since it's prepared in advance for us
+        "    add_bazel_data_dependency = False,",
         ")");
   }
 

--- a/tools/bazel_java_integration_test.bzl
+++ b/tools/bazel_java_integration_test.bzl
@@ -74,9 +74,7 @@ def bazel_java_integration_test(name, srcs=[], deps=None, runtime_deps=[],
   if not test_class:
     test_class = "%s.%s" % (_java_package(), name)
   add_deps = [
-    str(Label("//java/build/bazel/tests/integration")),
-    "@org_hamcrest_core//jar",
-    "@org_junit//jar",
+    str(Label("//java/build/bazel/tests/integration:workspace_driver")),
   ]
   if srcs:
     deps = (deps or []) + add_deps

--- a/tools/bazel_java_integration_test.bzl
+++ b/tools/bazel_java_integration_test.bzl
@@ -62,7 +62,7 @@ def _java_package():
 
 def bazel_java_integration_test(name, srcs=[], deps=None, runtime_deps=[], data=[],
                                 jvm_flags=[], test_class=None,
-                                #flag to allow bazel_integration_testing own tests to work
+                                # flag to allow bazel_integration_testing own tests to work
                                 add_bazel_data_dependency = True,
                                 versions=BAZEL_VERSIONS, **kwargs):
   """A wrapper around java_test that create several java tests, one per version

--- a/tools/bazel_java_integration_test.bzl
+++ b/tools/bazel_java_integration_test.bzl
@@ -60,8 +60,10 @@ def _java_package():
   return ".".join(segments[idx+1:])
 
 
-def bazel_java_integration_test(name, srcs=[], deps=None, runtime_deps=[],
+def bazel_java_integration_test(name, srcs=[], deps=None, runtime_deps=[], data=[],
                                 jvm_flags=[], test_class=None,
+                                #flag to allow bazel_integration_testing own tests to work
+                                add_bazel_data_dependency = True,
                                 versions=BAZEL_VERSIONS, **kwargs):
   """A wrapper around java_test that create several java tests, one per version
      of Bazel.
@@ -81,10 +83,13 @@ def bazel_java_integration_test(name, srcs=[], deps=None, runtime_deps=[],
   else:
     runtime_deps = runtime_deps + add_deps
   for version in versions:
+    if add_bazel_data_dependency:
+      data = data + ["@build_bazel_bazel_%s//:bazel" % version.replace(".", "_")]
     native.java_test(
         name = "%s/bazel%s" % (name, version),
         jvm_flags = ["-Dbazel.version=" + version],
         srcs = srcs,
+        data = data,
         test_class = test_class,
         deps = deps,
         runtime_deps = runtime_deps,


### PR DESCRIPTION
@damienmg I did two things here as the two separate commits suggest:
1. I minimized the dependencies of `bazel_java_integration_test` rule itself thanks to @natansil's work in #33 which separated between the `WorkspaceDriver` and the `BazelBaseTestCase`. This means users don't have to use junit/hamcrest.
2. I noticed that each test target has a data dependency on all of the bazel installers so //test/foo/bazel0.8.0 has a data dependency on all of the installers. AFAIU this can have an impact on remote execution since they will all need to be sent even though they're not needed, right? 
I moved the dependency into the rule itself instead of the library.
This meant opening a small backdoor for one of our own tests but I think the tradeoff is relevant.

WDYT?