### PR TITLE
Enable CI testing on macOS

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,3 +10,8 @@ platforms:
     - "..."
     test_targets:
     - "..."
+  macos:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."


### PR DESCRIPTION
I remember that we disabled it, because it took too long on macOS, but OTOH the Linux builds only take ~5 minutes.

Let's try to activate it again and see what happens.