### PR TITLE
Add bazel RC support

### DIFF
--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -19,7 +19,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -19,12 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -114,13 +109,13 @@ public class WorkspaceDriver {
    * Prepare bazel for running, and return the {@link Command} object to run it.
    */
   public Command bazel(String... args) {
-    return bazel(null, args);
+    return bazel(Optional.empty(), args);
   }
 
   /**
    * Prepare bazel for running, and return the {@link Command} object to run it.
    */
-  public Command bazel(Path bazelrcFile, String... args) {
+  public Command bazel(Optional<Path> bazelrcFile, String... args) {
     return bazel(bazelrcFile, new ArrayList<>(Arrays.asList(args)));
   }
 
@@ -128,13 +123,13 @@ public class WorkspaceDriver {
    * Prepare bazel for running, and return the {@link Command} object to run it.
    */
   public Command bazel(Iterable<String> args) {
-    return bazel(null, args);
+    return bazel(Optional.empty(), args);
   }
 
   /**
    * Prepare bazel for running, and return the {@link Command} object to run it.
    */
-  public Command bazel(Path bazelrcFile, Iterable<String> args) {
+  public Command bazel(Optional<Path> bazelrcFile, Iterable<String> args) {
     return runBazelInDirectory(Paths.get(""), bazelrcFile, args);
   }
 
@@ -143,16 +138,16 @@ public class WorkspaceDriver {
   }
 
   public Command runBazelInDirectory(Path relativeToWorksapceDir, Iterable<String> args) {
-    return runBazelInDirectory(relativeToWorksapceDir, null, args);
+    return runBazelInDirectory(relativeToWorksapceDir, Optional.empty(), args);
   }
 
-  public Command runBazelInDirectory(Path relativeToWorksapceDir, Path bazelrcFile, Iterable<String> args) {
+  public Command runBazelInDirectory(Path relativeToWorksapceDir, Optional<Path> bazelrcFile, Iterable<String> args) {
     if (currentBazel == null) {
       throw new BazelWorkspaceDriverException("Cannot use bazel because no version was specified, "
               + "please call bazelVersion(version) before calling bazel(...).");
     }
 
-    String bazelRcPath = bazelrcFile == null ? "/dev/null" : workspace.resolve(bazelrcFile).toString();
+    String bazelRcPath = bazelrcFile.map(p -> workspace.resolve(p).toString()).orElse("/dev/null");
 
     List<String> command = new ArrayList<String>(Arrays.asList(
             currentBazel.toString(),

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -113,33 +113,53 @@ public class WorkspaceDriver {
   /**
    * Prepare bazel for running, and return the {@link Command} object to run it.
    */
-  public Command bazel(String... args) throws IOException {
-    return bazel(new ArrayList<>(Arrays.asList(args)));
+  public Command bazel(String... args) {
+    return bazel(null, args);
   }
 
   /**
    * Prepare bazel for running, and return the {@link Command} object to run it.
    */
-  public Command bazel(Iterable<String> args) throws IOException {
-    return runBazelInDirectory(Paths.get(""), args);
+  public Command bazel(Path bazelrcFile, String... args) {
+    return bazel(bazelrcFile, new ArrayList<>(Arrays.asList(args)));
   }
 
-  public Command runBazelInDirectory(Path relativeDir, String... args) throws IOException {
+  /**
+   * Prepare bazel for running, and return the {@link Command} object to run it.
+   */
+  public Command bazel(Iterable<String> args) {
+    return bazel(null, args);
+  }
+
+  /**
+   * Prepare bazel for running, and return the {@link Command} object to run it.
+   */
+  public Command bazel(Path bazelrcFile, Iterable<String> args) {
+    return runBazelInDirectory(Paths.get(""), bazelrcFile, args);
+  }
+
+  public Command runBazelInDirectory(Path relativeDir, String... args) {
     return runBazelInDirectory(relativeDir, new ArrayList<>(Arrays.asList(args)));
   }
 
-  public Command runBazelInDirectory(Path relativeToWorksapceDir, Iterable<String> args) throws IOException {
+  public Command runBazelInDirectory(Path relativeToWorksapceDir, Iterable<String> args) {
+    return runBazelInDirectory(relativeToWorksapceDir, null, args);
+  }
+
+  public Command runBazelInDirectory(Path relativeToWorksapceDir, Path bazelrcFile, Iterable<String> args) {
     if (currentBazel == null) {
       throw new BazelWorkspaceDriverException("Cannot use bazel because no version was specified, "
               + "please call bazelVersion(version) before calling bazel(...).");
     }
+
+    String bazelRcPath = bazelrcFile == null ? "/dev/null" : workspace.resolve(bazelrcFile).toString();
 
     List<String> command = new ArrayList<String>(Arrays.asList(
             currentBazel.toString(),
             "--output_user_root=" + tmp,
             "--nomaster_bazelrc",
             "--max_idle_secs=10",
-            "--bazelrc=/dev/null"));
+            "--bazelrc=" + bazelRcPath));
     for (String arg : args) {
       command.add(arg);
     }

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -29,3 +29,10 @@ bazel_java_integration_test(
     test_class = "build.bazel.tests.integration.BazelIntegrationTestNoSourcesTest",
     runtime_deps = [":BazelIntegrationTestNoSourcesSrc"],
 )
+
+bazel_java_integration_test(
+    name = "WorkspaceDriverIntegrationTest",
+    srcs = ["WorkspaceDriverIntegrationTest.java"],
+    test_class = "build.bazel.tests.integration.WorkspaceDriverIntegrationTest",
+    deps = ["//java/build/bazel/tests/integration"],
+)

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -33,6 +33,5 @@ bazel_java_integration_test(
 bazel_java_integration_test(
     name = "WorkspaceDriverIntegrationTest",
     srcs = ["WorkspaceDriverIntegrationTest.java"],
-    test_class = "build.bazel.tests.integration.WorkspaceDriverIntegrationTest",
     deps = ["//java/build/bazel/tests/integration"],
 )

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -22,10 +22,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,7 +73,7 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
     setUpTestSuit("IntegrationTestSuiteTest");
     driver.scratchFile(".bazelrc", "test --javacopt=\"-InvalidFlag\"");
 
-    Command cmd = driver.bazel(Paths.get(".bazelrc"), "test", "//:IntegrationTestSuiteTest");
+    Command cmd = driver.bazel(Optional.of(Paths.get(".bazelrc")), "test", "//:IntegrationTestSuiteTest");
 
     org.hamcrest.MatcherAssert.assertThat(cmd.run(), not((successfulExitCode(cmd))));
     assertThat(cmd.getErrorLines()).contains("java.lang.IllegalArgumentException: invalid flag: -InvalidFlag");

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -22,13 +22,15 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 
 /** {@link BazelBaseTestCase}Test */
@@ -60,28 +62,13 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
 
   @Test
   public void testTestSuiteExists() throws Exception {
-    setUpTestSuit("IntegrationTestSuiteTest");
+    loadIntegrationTestRuleIntoWorkspace();
+    setupPassingTest("IntegrationTestSuiteTest");
 
     Command cmd = driver.bazel("test", "//:IntegrationTestSuiteTest");
     final int exitCode = cmd.run();
 
     org.hamcrest.MatcherAssert.assertThat(exitCode, is(successfulExitCode(cmd)));
-  }
-
-  @Test
-  public void testUseBazelRcFile() throws Exception {
-    setUpTestSuit("IntegrationTestSuiteTest");
-    driver.scratchFile(".bazelrc", "test --javacopt=\"-InvalidFlag\"");
-
-    Command cmd = driver.bazel(Optional.of(Paths.get(".bazelrc")), "test", "//:IntegrationTestSuiteTest");
-
-    org.hamcrest.MatcherAssert.assertThat(cmd.run(), not((successfulExitCode(cmd))));
-    assertThat(cmd.getErrorLines()).contains("java.lang.IllegalArgumentException: invalid flag: -InvalidFlag");
-  }
-
-  private void setUpTestSuit(String testName) throws Exception {
-    loadIntegrationTestRuleIntoWorkspace();
-    setupPassingTest(testName);
   }
 
   private TypeSafeDiagnosingMatcher<Integer> successfulExitCode(

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
     @Test
-    public void testBazelRc() throws Exception {
+    public void testWorkspaceWithBazelRcFile() throws Exception {
         String testName = "TestMe";
 
         driver.scratchFile("WORKSPACE", workspaceWithJunit());

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
@@ -32,28 +32,6 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
         assertTrue("stderr contains InvalidOpt failure", cmd.getErrorLines().stream().anyMatch(x -> x.contains("-InvalidOpt")));
     }
 
-    private List<String> testLabelNamed(String name) {
-        return Arrays.asList(
-                "java_test(",
-                "  name = '" + name + "',",
-                "  srcs = ['"+ name +".java'],",
-                "  test_class = 'build.bazel.tests.integration." + name + "',",
-                "  deps = ['@org_junit//jar'],",
-                ")"
-        );
-    }
-
-    private List<String> passingTestNamed(String name) {
-        return Arrays.asList(
-                "package build.bazel.tests.integration;",
-                "import org.junit.Test;",
-                "public class " + name + " {",
-                "  @Test",
-                "  public void testSuccess() {",
-                "  }",
-                "}");
-    }
-
     private void writeWorkspaceFileWithRepositories(String... repos) throws IOException {
         Stream<String> reposDec = Arrays.stream(repos).map(WorkspaceDriverIntegrationTest::repositoryDeclarationFor);
 
@@ -61,13 +39,6 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
                 "workspace(name = 'driver_integration_tests')",
                 reposDec.reduce("", (acc, cur) -> acc + cur)
         );
-    }
-
-    private static String repositoryDeclarationFor(final String repoName) {
-        return "local_repository(\n" +
-                "    name = \"" + repoName + "\",\n" +
-                "    path = \"./external/" + repoName + "\"\n" +
-                ")\n";
     }
 
     private void addExternalRepositoryFor(final String repoName, final String repoJarName) throws IOException {
@@ -79,5 +50,34 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
                 "    jars = ['" + repoJarName + "'],\n" +
                 "    visibility = ['//visibility:public']\n" +
                 ")\n");
+    }
+
+    private static List<String> testLabelNamed(String name) {
+        return Arrays.asList(
+                "java_test(",
+                "  name = '" + name + "',",
+                "  srcs = ['"+ name +".java'],",
+                "  test_class = 'build.bazel.tests.integration." + name + "',",
+                "  deps = ['@org_junit//jar'],",
+                ")"
+        );
+    }
+
+    private static List<String> passingTestNamed(String name) {
+        return Arrays.asList(
+                "package build.bazel.tests.integration;",
+                "import org.junit.Test;",
+                "public class " + name + " {",
+                "  @Test",
+                "  public void testSuccess() {",
+                "  }",
+                "}");
+    }
+
+    private static String repositoryDeclarationFor(final String repoName) {
+        return "local_repository(\n" +
+                "    name = \"" + repoName + "\",\n" +
+                "    path = \"./external/" + repoName + "\"\n" +
+                ")\n";
     }
 }

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
@@ -24,7 +24,7 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
         Command cmd = driver.bazel(Optional.of(Paths.get(".bazelrc")), "test", "//:TestMe");
         int returnCode = cmd.run();
 
-        assertEquals("bazel test return code", 1, returnCode);
+        assertNotEquals("bazel test return code", 0, returnCode);
         assertTrue("stderr contains InvalidOpt failure", cmd.getErrorLines().stream().anyMatch(x -> x.contains("-InvalidOpt")));
     }
 

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
@@ -1,0 +1,62 @@
+package build.bazel.tests.integration;
+
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
+    @Test
+    public void testBazelRc() throws Exception {
+        String testName = "TestMe";
+
+        driver.scratchFile("WORKSPACE", workspaceWithJunit());
+        driver.scratchFile("BUILD.bazel", testLabelNamed(testName));
+        driver.scratchFile("TestMe.java", passingTestNamed(testName));
+
+        driver.scratchFile(".bazelrc", "test --javacopt=\"-InvalidOpt\"");
+
+        Command cmd = driver.bazel(Optional.of(Paths.get(".bazelrc")), "test", "//:TestMe");
+        int returnCode = cmd.run();
+
+        assertEquals("bazel test return code", 1, returnCode);
+        assertTrue("stderr contains InvalidOpt failure", cmd.getErrorLines().stream().anyMatch(x -> x.contains("-InvalidOpt")));
+    }
+
+    private List<String> testLabelNamed(String name) {
+        return Arrays.asList(
+                "java_test(",
+                "  name = '" + name + "',",
+                "  srcs = ['"+ name +".java'],",
+                "  test_class = 'build.bazel.tests.integration." + name + "',",
+                "  deps = ['@org_junit//jar'],",
+                ")"
+        );
+    }
+
+    private List<String> passingTestNamed(String name) {
+        return Arrays.asList(
+                "package build.bazel.tests.integration;",
+                "import org.junit.Test;",
+                "public class " + name + " {",
+                "  @Test",
+                "  public void testSuccess() {",
+                "  }",
+                "}");
+    }
+
+    private List<String> workspaceWithJunit() {
+        return Arrays.asList(
+                "workspace(name = 'driver_integration_tests')",
+                "maven_jar(",
+                "  name = 'org_junit',",
+                "  artifact = 'junit:junit:jar:4.11',",
+                ")"
+        );
+    }
+}


### PR DESCRIPTION
Current implementation uses `--bazelrc=/dev/null` which means that `bazel` will ignore `.bazelrc`. There are cases where this may block some use cases

CC: @natansil @ittaiz 