### PR TITLE
WorkspaceDriver: add a currentWorkspace()

### DIFF
--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -42,6 +42,13 @@ public class WorkspaceDriver {
    */
   private Path workspace = null;
 
+  /**
+   * Returns the current workspace path
+   */
+  public Path getCurrentWorkspace() {
+    return workspace;
+  }
+
   public static void setUpClass() throws IOException {
     String environmentTempDirectory = System.getenv("TEST_TMPDIR");
     if (environmentTempDirectory == null) {

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -45,7 +45,7 @@ public class WorkspaceDriver {
   /**
    * Returns the current workspace path
    */
-  public Path getCurrentWorkspace() {
+  public Path currentWorkspace() {
     return workspace;
   }
 

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +40,16 @@ public class WorkspaceDriverTest {
 
     Optional<Path> actualFilePath = findPath(driver.workspaceDirectoryContents(), knownFile);
     org.hamcrest.MatcherAssert.assertThat("the known file should be found in the workspace", actualFilePath, is(optionalWithValue()));
+  }
+
+  // Test that we get the actual workspace with getCurrentWorkspace()
+  @Test
+  public void fileExistsUnderWorkspacePath() throws IOException {
+    driver.scratchFile("test_workspace_file");
+    org.hamcrest.MatcherAssert.assertThat(
+        "test_workspace_file should be in the workspace",
+        new File(driver.getCurrentWorkspace().toFile(), "test_workspace_file").exists(),
+        is(true));
   }
 
   @Test

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
@@ -42,13 +42,13 @@ public class WorkspaceDriverTest {
     org.hamcrest.MatcherAssert.assertThat("the known file should be found in the workspace", actualFilePath, is(optionalWithValue()));
   }
 
-  // Test that we get the actual workspace with getCurrentWorkspace()
+  // Test that we get the actual workspace with currentWorkspace()
   @Test
   public void fileExistsUnderWorkspacePath() throws IOException {
     driver.scratchFile("test_workspace_file");
     org.hamcrest.MatcherAssert.assertThat(
         "test_workspace_file should be in the workspace",
-        new File(driver.getCurrentWorkspace().toFile(), "test_workspace_file").exists(),
+        new File(driver.currentWorkspace().toFile(), "test_workspace_file").exists(),
         is(true));
   }
 


### PR DESCRIPTION
The Eclipse Plugin test needs to inject the path of a workspace in the
command line flags to test its skylark aspect. Using
getCurrentWorkspace() it can knows the actual path of it.