### PR TITLE
support "bazel run" with arguments

### DIFF
--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -308,8 +308,18 @@ public class WorkspaceDriver {
                   "--max_idle_secs=10",
                   "--bazelrc=" + bazelRcPath));
 
-      command.addAll(args);
-      command.addAll(repositoryCache.bazelOptions());
+      // This would split the args "run //target -- hello world" into
+      // "run //target" and "-- hello world" ("hello world" being passed to the executable
+      // to run).
+      int terminator = args.indexOf("--");
+      if (terminator == -1) {
+        command.addAll(args);
+        command.addAll(repositoryCache.bazelOptions());
+      } else {
+        command.addAll(args.subList(0, terminator));
+        command.addAll(repositoryCache.bazelOptions());
+        command.addAll(args.subList(terminator, args.size()));
+      }
 
       Path relativeToWorkspaceFullPath = workspace.resolve(workingDirectory);
 


### PR DESCRIPTION
Bug: The repository cache was specified at the very end of the
arguments given to BazelCommand, meaning that with "bazel run //foo --
arg" it would end up as an additional argument to the executable.