### PR TITLE
Replace usage of native http/git rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,8 @@
 workspace(name = "build_bazel_integration_testing")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 ## Sanity checks
 
 git_repository(
@@ -22,7 +25,7 @@ format_repositories()
 
 ## Python
 
-new_http_archive(
+http_archive(
     name = "com_google_python_gflags",
     build_file_content = """
 py_library(


### PR DESCRIPTION
Per https://groups.google.com/d/msg/bazel-discuss/dO2MHQLwJF0/2OXHjMAaAAAJ the native
implementations of these rules will be retired in favour of their skylark
versions. Replace usage with the skylark versions and test with:

```
--incompatible_remove_native_git_repository --incompatible_remove_native_http_archive
```