### PR TITLE
Add GET_LATEST_BAZEL_VERSIONS method

### DIFF
--- a/tools/common.bzl
+++ b/tools/common.bzl
@@ -16,13 +16,13 @@ load("//tools:bazel_hash_dict.bzl", "BAZEL_HASH_DICT")
 
 BAZEL_VERSIONS = BAZEL_HASH_DICT.keys()
 
-def zfill(v, l=5):
+def _zfill(v, l=5):
   """zfill a string by padding 0s to the left of the string till it is the link
   specified by l.
   """
   return "0" * (l - len(v)) + v
 
-def unfill(v, l=5):
+def _unfill(v, l=5):
   """unfill takes a zfilled string and returns it to the original value"""
   return [
       int(v[l * i: l * (i+1)])
@@ -42,7 +42,7 @@ def GET_LATEST_BAZEL_VERSIONS(count=3):
   """
   version_tuple_list = []
   for v in BAZEL_VERSIONS:
-    version_tuple_list.append("".join([zfill(x, 5) for x in v.split(".")]))
+    version_tuple_list.append("".join([_zfill(x, 5) for x in v.split(".")]))
 
   already_handled_major_minors = []
   toReturn = []
@@ -59,7 +59,6 @@ def GET_LATEST_BAZEL_VERSIONS(count=3):
 
     already_handled_major_minors.append(major_minor)
 
-    unfilled = unfill(v)
-    toReturn.append(unfilled)
+    toReturn.append(_unfill(v))
 
   return [".".join(v) for v in toReturn]

--- a/tools/common.bzl
+++ b/tools/common.bzl
@@ -15,3 +15,51 @@
 load("//tools:bazel_hash_dict.bzl", "BAZEL_HASH_DICT")
 
 BAZEL_VERSIONS = BAZEL_HASH_DICT.keys()
+
+def zfill(v, l=5):
+  """zfill a string by padding 0s to the left of the string till it is the link
+  specified by l.
+  """
+  return "0" * (l - len(v)) + v
+
+def unfill(v, l=5):
+  """unfill takes a zfilled string and returns it to the original value"""
+  return [
+      int(v[l * i: l * (i+1)])
+      for i in range(len(v) / l)
+  ]
+
+def GET_LATEST_BAZEL_VERSIONS(count=3):
+  """GET_LATEST_BAZEL_VERSIONS count and returns a list
+  of the latest $count minor versions at their latest patch.
+
+  Example:
+
+  ["0.1.0", "0.1.1", "0.2.0", "0.3.0"] => ["0.1.1", "0.2.0", "0.3.0"]
+
+  Arguments:
+    count: The number of versions to return.
+  """
+  version_tuple_list = []
+  for v in BAZEL_VERSIONS:
+    version_tuple_list.append("".join([zfill(x, 5) for x in v.split(".")]))
+
+  already_handled_major_minors = []
+  toReturn = []
+  # By padding everything with a consistent number of 0s we can sort using
+  # string sort and get a list in order.
+  for v in reversed(sorted(version_tuple_list)):
+    if len(toReturn) >= count:
+      break
+
+    major_minor = v[0:10]
+
+    if major_minor in already_handled_major_minors:
+      continue
+
+    already_handled_major_minors.append(major_minor)
+
+    unfilled = unfill(v)
+    toReturn.append(unfilled)
+
+  return [".".join(v) for v in toReturn]


### PR DESCRIPTION
It returns a certain number of bazel versions. It allows you to test the
latest 3 minor versions of Bazel without testing all the patch versions
or having to hardcode any values.