### PR TITLE
Update rules_go to 0.16.2.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "gazelle")
+load("@bazel_gazelle//:def.bzl", "gazelle")
 
 package_group(
     name = "internal",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,8 +60,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+    sha256 = "f87fa87475ea107b3c69196f39c82b7bbf58fe27c62a338684c20ca17d1d8613",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz",
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
@@ -69,6 +75,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_depen
 go_rules_dependencies()
 
 go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
 
 #### Use remote resources
 

--- a/bazel_integration_test.bzl
+++ b/bazel_integration_test.bzl
@@ -19,8 +19,8 @@ load(
 )
 load(
     "//tools:repositories.bzl",
-    "bazel_binary",
     "bazel_binaries",
+    "bazel_binary",
 )
 load(
     "//tools:bazel_java_integration_test.bzl",

--- a/go/bazel_integration_test.bzl
+++ b/go/bazel_integration_test.bzl
@@ -18,38 +18,40 @@ load("//tools:repositories.bzl", "bazel_binaries")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 def _make_compatible_version_list():
-  toReturn = []
-  for v in BAZEL_VERSIONS:
-    major, minor, patch = v.split(".")
-    if int(major) == 0 and int(minor) >= 7:
-      toReturn.append("%s.%s.%s" % (major, minor, patch))
-  return toReturn
+    toReturn = []
+    for v in BAZEL_VERSIONS:
+        major, minor, patch = v.split(".")
+        if int(major) == 0 and int(minor) >= 7:
+            toReturn.append("%s.%s.%s" % (major, minor, patch))
+    return toReturn
 
 RULES_GO_COMPATIBLE_BAZEL_VERSION = _make_compatible_version_list()
 
-def bazel_go_integration_test(name,
-                              srcs,
-                              deps = [],
-                              data = [],
-                              versions = RULES_GO_COMPATIBLE_BAZEL_VERSION,
-                              **kwargs):
-  """A wrapper around go_test that create several go tests, one per version
-     of Bazel.
-
-     Args:
-       versions: list of version of bazel to create a test for. Each test
-         will be named `<name>/bazel<version>`.
-       See go_test for the other arguments.
-  """
-  for version in versions:
-    go_test(
-        name = "%s/bazel%s" % (name, version),
-        srcs = srcs,
-        deps = deps,
-        data = [
-            "@build_bazel_bazel_%s//:bazel_binary" % version.replace(".", "_"),
-        ] + data,
-        x_defs = {
-            "github.com/bazelbuild/bazel-integration-testing/go.BazelVersion": version,
-        },
-        **kwargs)
+def bazel_go_integration_test(
+        name,
+        srcs,
+        deps = [],
+        data = [],
+        versions = RULES_GO_COMPATIBLE_BAZEL_VERSION,
+        **kwargs):
+    """A wrapper around go_test that create several go tests, one per version
+       of Bazel.
+  
+       Args:
+         versions: list of version of bazel to create a test for. Each test
+           will be named `<name>/bazel<version>`.
+         See go_test for the other arguments.
+    """
+    for version in versions:
+        go_test(
+            name = "%s/bazel%s" % (name, version),
+            srcs = srcs,
+            deps = deps,
+            data = [
+                "@build_bazel_bazel_%s//:bazel_binary" % version.replace(".", "_"),
+            ] + data,
+            x_defs = {
+                "github.com/bazelbuild/bazel-integration-testing/go.BazelVersion": version,
+            },
+            **kwargs
+        )

--- a/private/format.bzl
+++ b/private/format.bzl
@@ -73,19 +73,19 @@ def format_repositories():
   http_file(
       name = "io_bazel_buildifier_linux",
       urls = [
-          "https://github.com/bazelbuild/buildtools/releases/download/0.15.0/buildifier"
+          "https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier"
       ],
       sha256 = (
-          "0dea01a7a511797878f486e6ed8e549980c0710a0a116c8ee953d4e26de41515"),
+          "1cf35c463944003ceb3c3716d7fc489d3d70625e34a8127dfd8b272afad7e0fd"),
       executable = True,
   )
 
   http_file(
       name = "io_bazel_buildifier_darwin",
       urls = [
-          "https://github.com/bazelbuild/buildtools/releases/download/0.15.0/buildifier.osx"
+          "https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier.osx"
       ],
       sha256 = (
-          "860378a2badba9517e523e20f152ef1ca16234e0ca462a1d71e5dbee7d506771"),
+          "66a569152bf59a527000941758a25f1dd03d6e26302d7982fd8aee25e552a10c"),
       executable = True,
   )

--- a/private/format.bzl
+++ b/private/format.bzl
@@ -25,18 +25,19 @@ load(
 )
 
 def _com_github_google_yapf_repository_impl(rctx):
-  rctx.download_and_extract(
-      url = "https://github.com/google/yapf/archive/v0.21.0.tar.gz",
-      sha256 = "b930c1bc8233a9944671db7bdd6c9dc9ba2343b08b726a2dd0bff37ce1815baa",
-      stripPrefix = "yapf-0.21.0")
-  rctx.file("BUILD", """
+    rctx.download_and_extract(
+        url = "https://github.com/google/yapf/archive/v0.21.0.tar.gz",
+        sha256 = "b930c1bc8233a9944671db7bdd6c9dc9ba2343b08b726a2dd0bff37ce1815baa",
+        stripPrefix = "yapf-0.21.0",
+    )
+    rctx.file("BUILD", """
 alias(
     name="yapf",
     actual="//yapf:yapf",
     visibility = ["//visibility:public"],
 )
 """)
-  rctx.file("yapf/BUILD", """
+    rctx.file("yapf/BUILD", """
 py_binary(
     name="yapf",
     srcs=glob(["**/*.py"]),
@@ -50,42 +51,45 @@ _com_github_google_yapf_repository = repository_rule(
 )
 
 def format_repositories():
-  _com_github_google_yapf_repository(name = "com_github_google_yapf")
+    _com_github_google_yapf_repository(name = "com_github_google_yapf")
 
-  http_archive(
-      name = "io_bazel",
-      urls = [
-          "https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-dist.zip"
-      ],
-      sha256 = (
-          "23e4281c3628cbd746da3f51330109bbf69780bd64461b63b386efae37203f20"),
-  )
+    http_archive(
+        name = "io_bazel",
+        urls = [
+            "https://github.com/bazelbuild/bazel/releases/download/0.17.1/bazel-0.17.1-dist.zip",
+        ],
+        sha256 = (
+            "23e4281c3628cbd746da3f51330109bbf69780bd64461b63b386efae37203f20"
+        ),
+    )
 
-  java_import_external(
-      name = "google_java_format",
-      licenses = ["notice"],  # Apache 2.0
-      jar_urls = [
-          "https://github.com/google/google-java-format/releases/download/google-java-format-1.5/google-java-format-1.5-all-deps.jar"
-      ],
-      jar_sha256 = ("7b839bb7534a173f0ed0cd0e9a583181d20850fcec8cf6e3800e4420a1fad184"),
-  )
+    java_import_external(
+        name = "google_java_format",
+        licenses = ["notice"],  # Apache 2.0
+        jar_urls = [
+            "https://github.com/google/google-java-format/releases/download/google-java-format-1.5/google-java-format-1.5-all-deps.jar",
+        ],
+        jar_sha256 = ("7b839bb7534a173f0ed0cd0e9a583181d20850fcec8cf6e3800e4420a1fad184"),
+    )
 
-  http_file(
-      name = "io_bazel_buildifier_linux",
-      urls = [
-          "https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier"
-      ],
-      sha256 = (
-          "1cf35c463944003ceb3c3716d7fc489d3d70625e34a8127dfd8b272afad7e0fd"),
-      executable = True,
-  )
+    http_file(
+        name = "io_bazel_buildifier_linux",
+        urls = [
+            "https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier",
+        ],
+        sha256 = (
+            "1cf35c463944003ceb3c3716d7fc489d3d70625e34a8127dfd8b272afad7e0fd"
+        ),
+        executable = True,
+    )
 
-  http_file(
-      name = "io_bazel_buildifier_darwin",
-      urls = [
-          "https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier.osx"
-      ],
-      sha256 = (
-          "66a569152bf59a527000941758a25f1dd03d6e26302d7982fd8aee25e552a10c"),
-      executable = True,
-  )
+    http_file(
+        name = "io_bazel_buildifier_darwin",
+        urls = [
+            "https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier.osx",
+        ],
+        sha256 = (
+            "66a569152bf59a527000941758a25f1dd03d6e26302d7982fd8aee25e552a10c"
+        ),
+        executable = True,
+    )

--- a/tools/bazel_java_integration_test.bzl
+++ b/tools/bazel_java_integration_test.bzl
@@ -23,14 +23,14 @@ load(
 )
 
 def _bazel_java_integration_test_properties_impl(ctx):
-  properties = [
-      "bazel.version=" + ctx.attr.bazel_version,
-      "bazel.workspace=" + ctx.workspace_name,
-      "bazel.external.deps=" +
-      ",".join([d.short_path for d in ctx.files.external_deps]),
-  ]
+    properties = [
+        "bazel.version=" + ctx.attr.bazel_version,
+        "bazel.workspace=" + ctx.workspace_name,
+        "bazel.external.deps=" +
+        ",".join([d.short_path for d in ctx.files.external_deps]),
+    ]
 
-  ctx.actions.write(ctx.outputs.properties, "\n".join(properties))
+    ctx.actions.write(ctx.outputs.properties, "\n".join(properties))
 
 bazel_java_integration_test_properties_ = rule(
     attrs = {
@@ -44,122 +44,128 @@ bazel_java_integration_test_properties_ = rule(
 )
 
 def _index(lst, el):
-  return lst.index(el) if el in lst else -1
+    return lst.index(el) if el in lst else -1
 
 def _java_package():
-  # Adaptation of the java class finding library from Bazel.
-  path = native.package_name()
-  segments = path.split("/")
-  roots = [
-      segments.index(i) for i in ["java", "javatests", "src"] if i in segments
-  ]
-  if not len(roots):
-    return ".".join(segments)
-  idx = min(roots)
-  is_src = segments[idx] == "src"
-  check_mvn_idx = idx if is_src else -1
-  if idx == 0 or is_src:
-    # Check for a nested root directory.
-    end_segments = segments[idx + 1:-1]
-    src_segment = end_segments.index("src") if "src" in end_segments else -1
-    if is_src:
-      end_segments_idx = [
-          end_segments.index(i)
-          for i in ["java", "javatests", "src"]
-          if i in end_segments
-      ]
-      if end_segments_idx:
-        src_segment = min(end_segments_idx)
-    if src_segment >= 0:
-      next = end_segments[src_segment + 1]
-      if next in ["com", "org", "net"]:
-        # Check for common first element of java package, to avoid false
-        # positives.
-        idx += src_segment + 1
-      elif next in ["main", "test"]:
-        # Also accept maven style src/(main|test)/(java|resources).
-        check_mvn_idx = idx + src_segment + 1
-  # Check for (main|test)/(java|resources) after /src/.
-  if check_mvn_idx >= 0 and check_mvn_idx < len(segments) - 2:
-    if segments[check_mvn_idx + 1] in [
-        "main", "test"
-    ] and segments[check_mvn_idx + 2] in ["java", "resources"]:
-      idx = check_mvn_idx + 2
-  if idx < 0:
-    return ".".join(segments)
-  return ".".join(segments[idx + 1:])
+    # Adaptation of the java class finding library from Bazel.
+    path = native.package_name()
+    segments = path.split("/")
+    roots = [
+        segments.index(i)
+        for i in ["java", "javatests", "src"]
+        if i in segments
+    ]
+    if not len(roots):
+        return ".".join(segments)
+    idx = min(roots)
+    is_src = segments[idx] == "src"
+    check_mvn_idx = idx if is_src else -1
+    if idx == 0 or is_src:
+        # Check for a nested root directory.
+        end_segments = segments[idx + 1:-1]
+        src_segment = end_segments.index("src") if "src" in end_segments else -1
+        if is_src:
+            end_segments_idx = [
+                end_segments.index(i)
+                for i in ["java", "javatests", "src"]
+                if i in end_segments
+            ]
+            if end_segments_idx:
+                src_segment = min(end_segments_idx)
+        if src_segment >= 0:
+            next = end_segments[src_segment + 1]
+            if next in ["com", "org", "net"]:
+                # Check for common first element of java package, to avoid false
+                # positives.
+                idx += src_segment + 1
+            elif next in ["main", "test"]:
+                # Also accept maven style src/(main|test)/(java|resources).
+                check_mvn_idx = idx + src_segment + 1
+
+    # Check for (main|test)/(java|resources) after /src/.
+    if check_mvn_idx >= 0 and check_mvn_idx < len(segments) - 2:
+        if segments[check_mvn_idx + 1] in [
+            "main",
+            "test",
+        ] and segments[check_mvn_idx + 2] in ["java", "resources"]:
+            idx = check_mvn_idx + 2
+    if idx < 0:
+        return ".".join(segments)
+    return ".".join(segments[idx + 1:])
 
 def bazel_java_integration_test(
-    name,
-    srcs = [],
-    deps = None,
-    runtime_deps = [],
-    data = [],
-    jvm_flags = [],
-    test_class = None,
-    external_deps = [],
-    # flag to allow bazel_integration_testing own tests to work
-    add_bazel_data_dependency = True,
-    versions = BAZEL_VERSIONS,
-    **kwargs):
-  """A wrapper around java_test that create several java tests, one per version
-     of Bazel.
+        name,
+        srcs = [],
+        deps = None,
+        runtime_deps = [],
+        data = [],
+        jvm_flags = [],
+        test_class = None,
+        external_deps = [],
+        # flag to allow bazel_integration_testing own tests to work
+        add_bazel_data_dependency = True,
+        versions = BAZEL_VERSIONS,
+        **kwargs):
+    """A wrapper around java_test that create several java tests, one per version
+       of Bazel.
+  
+       Args:
+         versions: list of version of bazel to create a test for. Each test
+           will be named `<name>/bazel<version>`.
+         See java_test for the other arguments.
+    """
+    if not test_class:
+        test_class = "%s.%s" % (_java_package(), name)
+    add_deps = [
+        str(Label("//java/build/bazel/tests/integration:workspace_driver")),
+    ]
+    if srcs:
+        deps = (deps or []) + add_deps
+    else:
+        runtime_deps = runtime_deps + add_deps
+    for version in versions:
+        prop_rule = "%s/config%s" % (name, version)
+        bazel_java_integration_test_properties_(
+            name = prop_rule,
+            bazel_version = version,
+            external_deps = external_deps,
+        )
 
-     Args:
-       versions: list of version of bazel to create a test for. Each test
-         will be named `<name>/bazel<version>`.
-       See java_test for the other arguments.
-  """
-  if not test_class:
-    test_class = "%s.%s" % (_java_package(), name)
-  add_deps = [
-      str(Label("//java/build/bazel/tests/integration:workspace_driver")),
-  ]
-  if srcs:
-    deps = (deps or []) + add_deps
-  else:
-    runtime_deps = runtime_deps + add_deps
-  for version in versions:
-    prop_rule = "%s/config%s" % (name, version)
-    bazel_java_integration_test_properties_(
-        name = prop_rule,
-        bazel_version = version,
-        external_deps = external_deps,
+        cur_data = data + external_deps + [prop_rule + ".properties"]
+        if add_bazel_data_dependency:
+            cur_data += ["@build_bazel_bazel_%s//:bazel_binary" % version.replace(".", "_")]
+        native.java_test(
+            name = "%s/bazel%s" % (name, version),
+            jvm_flags = [
+                "-Dbazel.configuration=$(location %s.properties)" % prop_rule,
+            ] + jvm_flags,
+            srcs = srcs,
+            data = cur_data,
+            test_class = test_class,
+            deps = deps,
+            runtime_deps = runtime_deps,
+            **kwargs
+        )
+    native.test_suite(
+        name = name,
+        tests = [":%s/bazel%s" % (name, version) for version in versions],
     )
 
-    cur_data = data + external_deps + [prop_rule + ".properties"]
-    if add_bazel_data_dependency:
-      cur_data += ["@build_bazel_bazel_%s//:bazel_binary" % version.replace(".", "_")]
-    native.java_test(
-        name = "%s/bazel%s" % (name, version),
-        jvm_flags = [
-            "-Dbazel.configuration=$(location %s.properties)" % prop_rule
-        ] + jvm_flags,
-        srcs = srcs,
-        data = cur_data,
-        test_class = test_class,
-        deps = deps,
-        runtime_deps = runtime_deps,
-        **kwargs)
-  native.test_suite(
-      name = name,
-      tests = [":%s/bazel%s" % (name, version) for version in versions])
-
 def bazel_java_integration_test_deps(versions = BAZEL_VERSIONS):
-  bazel_binaries(versions)
+    bazel_binaries(versions)
 
-  # TODO(dmarting): Use http_file and relies on a mirror instead of maven_jar
-  native.maven_jar(
-      name = "com_google_guava",
-      artifact = "com.google.guava:guava:jar:21.0",
-  )
+    # TODO(dmarting): Use http_file and relies on a mirror instead of maven_jar
+    native.maven_jar(
+        name = "com_google_guava",
+        artifact = "com.google.guava:guava:jar:21.0",
+    )
 
-  native.maven_jar(
-      name = "org_hamcrest_core",
-      artifact = "org.hamcrest:hamcrest-core:jar:1.3",
-  )
+    native.maven_jar(
+        name = "org_hamcrest_core",
+        artifact = "org.hamcrest:hamcrest-core:jar:1.3",
+    )
 
-  native.maven_jar(
-      name = "org_junit",
-      artifact = "junit:junit:jar:4.11",
-  )
+    native.maven_jar(
+        name = "org_junit",
+        artifact = "junit:junit:jar:4.11",
+    )

--- a/tools/bazel_py_integration_test.bzl
+++ b/tools/bazel_py_integration_test.bzl
@@ -16,33 +16,36 @@
 load(":common.bzl", "BAZEL_VERSIONS")
 load(":repositories.bzl", "bazel_binaries")
 
-def bazel_py_integration_test(name,
-                              srcs,
-                              main = None,
-                              deps = [],
-                              versions = BAZEL_VERSIONS,
-                              **kwargs):
-  """A wrapper around py_test that create several python tests, one per version
-     of Bazel.
-
-     Args:
-       versions: list of version of bazel to create a test for. Each test
-         will be named `<name>/bazel<version>`.
-       See py_test for the other arguments.
-  """
-  if not main and len(srcs) == 1:
-    main = srcs[0]
-  for version in versions:
-    add_deps = [
-        str(Label("//bazel_integration_test:python")),
-        str(Label("//bazel_integration_test:python_version_" + version)),
-    ]
-    native.py_test(
-        name = "%s/bazel%s" % (name, version),
-        srcs = srcs,
-        main = main,
-        deps = deps + add_deps,
-        **kwargs)
-  native.test_suite(
-      name = name,
-      tests = [":%s/bazel%s" % (name, version) for version in versions])
+def bazel_py_integration_test(
+        name,
+        srcs,
+        main = None,
+        deps = [],
+        versions = BAZEL_VERSIONS,
+        **kwargs):
+    """A wrapper around py_test that create several python tests, one per version
+       of Bazel.
+  
+       Args:
+         versions: list of version of bazel to create a test for. Each test
+           will be named `<name>/bazel<version>`.
+         See py_test for the other arguments.
+    """
+    if not main and len(srcs) == 1:
+        main = srcs[0]
+    for version in versions:
+        add_deps = [
+            str(Label("//bazel_integration_test:python")),
+            str(Label("//bazel_integration_test:python_version_" + version)),
+        ]
+        native.py_test(
+            name = "%s/bazel%s" % (name, version),
+            srcs = srcs,
+            main = main,
+            deps = deps + add_deps,
+            **kwargs
+        )
+    native.test_suite(
+        name = name,
+        tests = [":%s/bazel%s" % (name, version) for version in versions],
+    )

--- a/tools/common.bzl
+++ b/tools/common.bzl
@@ -16,49 +16,50 @@ load("//tools:bazel_hash_dict.bzl", "BAZEL_HASH_DICT")
 
 BAZEL_VERSIONS = BAZEL_HASH_DICT.keys()
 
-def _zfill(v, l=5):
-  """zfill a string by padding 0s to the left of the string till it is the link
-  specified by l.
-  """
-  return "0" * (l - len(v)) + v
+def _zfill(v, l = 5):
+    """zfill a string by padding 0s to the left of the string till it is the link
+    specified by l.
+    """
+    return "0" * (l - len(v)) + v
 
-def _unfill(v, l=5):
-  """unfill takes a zfilled string and returns it to the original value"""
-  return [
-      int(v[l * i: l * (i+1)])
-      for i in range(len(v) / l)
-  ]
+def _unfill(v, l = 5):
+    """unfill takes a zfilled string and returns it to the original value"""
+    return [
+        int(v[l * i:l * (i + 1)])
+        for i in range(len(v) / l)
+    ]
 
-def GET_LATEST_BAZEL_VERSIONS(count=3):
-  """GET_LATEST_BAZEL_VERSIONS count and returns a list
-  of the latest $count minor versions at their latest patch.
+def GET_LATEST_BAZEL_VERSIONS(count = 3):
+    """GET_LATEST_BAZEL_VERSIONS count and returns a list
+    of the latest $count minor versions at their latest patch.
+  
+    Example:
+  
+    ["0.1.0", "0.1.1", "0.2.0", "0.3.0"] => ["0.1.1", "0.2.0", "0.3.0"]
+  
+    Arguments:
+      count: The number of versions to return.
+    """
+    version_tuple_list = []
+    for v in BAZEL_VERSIONS:
+        version_tuple_list.append("".join([_zfill(x, 5) for x in v.split(".")]))
 
-  Example:
+    already_handled_major_minors = []
+    toReturn = []
 
-  ["0.1.0", "0.1.1", "0.2.0", "0.3.0"] => ["0.1.1", "0.2.0", "0.3.0"]
+    # By padding everything with a consistent number of 0s we can sort using
+    # string sort and get a list in order.
+    for v in reversed(sorted(version_tuple_list)):
+        if len(toReturn) >= count:
+            break
 
-  Arguments:
-    count: The number of versions to return.
-  """
-  version_tuple_list = []
-  for v in BAZEL_VERSIONS:
-    version_tuple_list.append("".join([_zfill(x, 5) for x in v.split(".")]))
+        major_minor = v[0:10]
 
-  already_handled_major_minors = []
-  toReturn = []
-  # By padding everything with a consistent number of 0s we can sort using
-  # string sort and get a list in order.
-  for v in reversed(sorted(version_tuple_list)):
-    if len(toReturn) >= count:
-      break
+        if major_minor in already_handled_major_minors:
+            continue
 
-    major_minor = v[0:10]
+        already_handled_major_minors.append(major_minor)
 
-    if major_minor in already_handled_major_minors:
-      continue
+        toReturn.append(_unfill(v))
 
-    already_handled_major_minors.append(major_minor)
-
-    toReturn.append(_unfill(v))
-
-  return [".".join(v) for v in toReturn]
+    return [".".join(v) for v in toReturn]

--- a/tools/import.bzl
+++ b/tools/import.bzl
@@ -18,32 +18,32 @@
 # Implementing bazel_git_dependency_archive would mean calling "git archive" directly.
 
 def _get_basename(url):
-  return url[url.rindex("/") + 1:]
+    return url[url.rindex("/") + 1:]
 
 def _bazel_external_dependency_archive_impl(repository_ctx):
-  build_lines = [
-      "filegroup(",
-      "    name = \"%s\"," % repository_ctx.name,
-      "    srcs = [",
-  ]
+    build_lines = [
+        "filegroup(",
+        "    name = \"%s\"," % repository_ctx.name,
+        "    srcs = [",
+    ]
 
-  for sha256 in repository_ctx.attr.srcs:
-    urls = repository_ctx.attr.srcs[sha256]
-    basename = sha256
-    repository_ctx.download(
-        url = urls,
-        sha256 = sha256,
-        output = basename,
-    )
-    build_lines.append("        \"%s\",  # %s" % (basename, urls[0]))
+    for sha256 in repository_ctx.attr.srcs:
+        urls = repository_ctx.attr.srcs[sha256]
+        basename = sha256
+        repository_ctx.download(
+            url = urls,
+            sha256 = sha256,
+            output = basename,
+        )
+        build_lines.append("        \"%s\",  # %s" % (basename, urls[0]))
 
-  build_lines += [
-      "    ],",
-      "    visibility = [\"//visibility:public\"],",
-      ")",
-  ]
+    build_lines += [
+        "    ],",
+        "    visibility = [\"//visibility:public\"],",
+        ")",
+    ]
 
-  repository_ctx.file("BUILD", "\n".join(build_lines))
+    repository_ctx.file("BUILD", "\n".join(build_lines))
 
 bazel_external_dependency_archive = repository_rule(
     attrs = {

--- a/tools/repositories.bzl
+++ b/tools/repositories.bzl
@@ -17,23 +17,24 @@ load(":common.bzl", "BAZEL_HASH_DICT", "BAZEL_VERSIONS")
 _BAZEL_BINARY_PACKAGE = "http://releases.bazel.build/{version}/release/bazel-{version}-installer-{platform}.sh"
 
 def _get_platform_name(rctx):
-  os_name = rctx.os.name.lower()
-  # We default on linux-x86_64 because we only support 2 platforms
-  return "darwin-x86_64" if os_name.startswith("mac os") else "linux-x86_64"
+    os_name = rctx.os.name.lower()
+
+    # We default on linux-x86_64 because we only support 2 platforms
+    return "darwin-x86_64" if os_name.startswith("mac os") else "linux-x86_64"
 
 def _get_installer(rctx):
-  platform = _get_platform_name(rctx)
-  version = rctx.attr.version
-  url = _BAZEL_BINARY_PACKAGE.format(version = version, platform = platform)
-  args = {"url": url, "type": "zip"}
-  if version in BAZEL_HASH_DICT and platform in BAZEL_HASH_DICT[version]:
-    args["sha256"] = BAZEL_HASH_DICT[version][platform]
-  rctx.download_and_extract(**args)
+    platform = _get_platform_name(rctx)
+    version = rctx.attr.version
+    url = _BAZEL_BINARY_PACKAGE.format(version = version, platform = platform)
+    args = {"url": url, "type": "zip"}
+    if version in BAZEL_HASH_DICT and platform in BAZEL_HASH_DICT[version]:
+        args["sha256"] = BAZEL_HASH_DICT[version][platform]
+    rctx.download_and_extract(**args)
 
 def _bazel_repository_impl(rctx):
-  _get_installer(rctx)
-  rctx.file("WORKSPACE", "workspace(name='%s')" % rctx.attr.name)
-  rctx.file("BUILD", """
+    _get_installer(rctx)
+    rctx.file("WORKSPACE", "workspace(name='%s')" % rctx.attr.name)
+    rctx.file("BUILD", """
 filegroup(
   name = "bazel_binary",
   srcs = ["bazel-real","bazel"],
@@ -54,8 +55,8 @@ Limitation: only support Linux and macOS for now.
 """
 
 def bazel_binaries(versions = BAZEL_VERSIONS):
-  """Download all bazel binaries specified in BAZEL_VERSIONS."""
-  for version in versions:
-    name = "build_bazel_bazel_" + version.replace(".", "_")
-    if not native.existing_rule(name):
-      bazel_binary(name = name, version = version)
+    """Download all bazel binaries specified in BAZEL_VERSIONS."""
+    for version in versions:
+        name = "build_bazel_bazel_" + version.replace(".", "_")
+        if not native.existing_rule(name):
+            bazel_binary(name = name, version = version)


### PR DESCRIPTION
The old version of rules_go currently set up (0.13.0) does not work on Windows, so this step is necessary to get started on that work.