### PR TITLE
Fix common.bzl

### DIFF
--- a/tools/common.bzl
+++ b/tools/common.bzl
@@ -16,49 +16,50 @@ load("//tools:bazel_hash_dict.bzl", "BAZEL_HASH_DICT")
 
 BAZEL_VERSIONS = BAZEL_HASH_DICT.keys()
 
-def _zfill(v, l=5):
-  """zfill a string by padding 0s to the left of the string till it is the link
-  specified by l.
-  """
-  return "0" * (l - len(v)) + v
+def _zfill(v, l = 5):
+    """zfill a string by padding 0s to the left of the string till it is the link
+    specified by l.
+    """
+    return "0" * (l - len(v)) + v
 
-def _unfill(v, l=5):
-  """unfill takes a zfilled string and returns it to the original value"""
-  return [
-      int(v[l * i: l * (i+1)])
-      for i in range(len(v) / l)
-  ]
+def _unfill(v, l = 5):
+    """unfill takes a zfilled string and returns it to the original value"""
+    return [
+        int(v[l * i:l * (i + 1)])
+        for i in range(len(v) // l)
+    ]
 
-def GET_LATEST_BAZEL_VERSIONS(count=3):
-  """GET_LATEST_BAZEL_VERSIONS count and returns a list
-  of the latest $count minor versions at their latest patch.
+def GET_LATEST_BAZEL_VERSIONS(count = 3):
+    """GET_LATEST_BAZEL_VERSIONS count and returns a list
+    of the latest $count minor versions at their latest patch.
 
-  Example:
+    Example:
 
-  ["0.1.0", "0.1.1", "0.2.0", "0.3.0"] => ["0.1.1", "0.2.0", "0.3.0"]
+    ["0.1.0", "0.1.1", "0.2.0", "0.3.0"] => ["0.1.1", "0.2.0", "0.3.0"]
 
-  Arguments:
-    count: The number of versions to return.
-  """
-  version_tuple_list = []
-  for v in BAZEL_VERSIONS:
-    version_tuple_list.append("".join([_zfill(x, 5) for x in v.split(".")]))
+    Arguments:
+      count: The number of versions to return.
+    """
+    version_tuple_list = []
+    for v in BAZEL_VERSIONS:
+        version_tuple_list.append("".join([_zfill(x, 5) for x in v.split(".")]))
 
-  already_handled_major_minors = []
-  toReturn = []
-  # By padding everything with a consistent number of 0s we can sort using
-  # string sort and get a list in order.
-  for v in reversed(sorted(version_tuple_list)):
-    if len(toReturn) >= count:
-      break
+    already_handled_major_minors = []
+    toReturn = []
 
-    major_minor = v[0:10]
+    # By padding everything with a consistent number of 0s we can sort using
+    # string sort and get a list in order.
+    for v in reversed(sorted(version_tuple_list)):
+        if len(toReturn) >= count:
+            break
 
-    if major_minor in already_handled_major_minors:
-      continue
+        major_minor = v[0:10]
 
-    already_handled_major_minors.append(major_minor)
+        if major_minor in already_handled_major_minors:
+            continue
 
-    toReturn.append(_unfill(v))
+        already_handled_major_minors.append(major_minor)
 
-  return [".".join(v) for v in toReturn]
+        toReturn.append(_unfill(v))
+
+    return [".".join(v) for v in toReturn]


### PR DESCRIPTION
To fix incompatible change: [incompatible_disallow_slash_operator](https://github.com/bazelbuild/bazel/issues/5823)

Fixed by `buildifier --lint=fix ./tools/common.bzl`