### PR TITLE
Add Windows Support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,17 +3,22 @@ platforms:
   ubuntu1404:
     build_targets:
     - "..."
+    test_flags:
+    - "--test_tag_filters=-no_linux"
     test_targets:
     - "..."
   ubuntu1604:
     build_targets:
     - "..."
+    test_flags:
+    - "--test_tag_filters=-no_linux"
     test_targets:
     - "..."
   macos:
     build_targets:
     - "..."
-    test_targets:
+    test_flags:
+    - "--test_tag_filters=-no_macos"
     - "..."
   windows:
     build_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,22 +3,16 @@ platforms:
   ubuntu1404:
     build_targets:
     - "..."
-    test_flags:
-    - "--test_output=all"
     test_targets:
     - "..."
   ubuntu1604:
     build_targets:
     - "..."
-    test_flags:
-    - "--test_output=all"
     test_targets:
     - "..."
   macos:
     build_targets:
     - "..."
-    test_flags:
-    - "--test_output=all"
     test_targets:
     - "..."
   windows:
@@ -30,6 +24,5 @@ platforms:
     - "--enable_runfiles"
     - "--test_tag_filters=-no_windows"
     - "--test_env=JAVA_HOME"
-    - "--test_output=all"
     test_targets:
     - "..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,6 +19,7 @@ platforms:
     - "..."
     test_flags:
     - "--test_tag_filters=-no_macos"
+    test_targets:
     - "..."
   windows:
     build_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,22 +3,16 @@ platforms:
   ubuntu1404:
     build_targets:
     - "..."
-    test_flags:
-    - "--test_tag_filters=-no_linux"
     test_targets:
     - "..."
   ubuntu1604:
     build_targets:
     - "..."
-    test_flags:
-    - "--test_tag_filters=-no_linux"
     test_targets:
     - "..."
   macos:
     build_targets:
     - "..."
-    test_flags:
-    - "--test_tag_filters=-no_macos"
     test_targets:
     - "..."
   windows:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -21,3 +21,15 @@ platforms:
     - "--test_output=all"
     test_targets:
     - "..."
+  windows:
+    build_targets:
+    - "..."
+    build_flags:
+    - "--enable_runfiles"
+    test_flags:
+    - "--enable_runfiles"
+    - "--test_tag_filters=-no_windows"
+    - "--test_env=JAVA_HOME"
+    - "--test_output=all"
+    test_targets:
+    - "..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,5 +24,6 @@ platforms:
     - "--enable_runfiles"
     - "--test_tag_filters=-no_windows"
     - "--test_env=JAVA_HOME"
+    - "--test_env=BAZEL_SH"
     test_targets:
     - "..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,7 +23,7 @@ platforms:
     test_flags:
     - "--enable_runfiles"
     - "--test_tag_filters=-no_windows"
-    - "--test_env=JAVA_HOME"
-    - "--test_env=BAZEL_SH"
+    - "--test_env=JAVA_HOME" # For building Java binary inside test
+    - "--test_env=BAZEL_SH"  # Make sure Bazel binary inside test can find the correct Bash (MSYS2 instead of Git)
     test_targets:
     - "..."

--- a/bazel_integration_test/test_base.py
+++ b/bazel_integration_test/test_base.py
@@ -80,8 +80,9 @@ class TestBase(unittest.TestCase):
 
   def SetBazelVersion(self, version):
     """Set the bazel version to use, e.g. 0.5.4."""
+    suffix = ".exe" if self.IsWindows() else ""
     if self._SetAndUnpackBazel(
-        "build_bazel_bazel_%s/bazel" % version.replace('.', '_')):
+        "build_bazel_bazel_%s/bazel%s" % (version.replace('.', '_'), suffix)):
       self.bazelVersion = version
     else:
       self.fail("Cannot find bazel version " + version)

--- a/go/bazel.go
+++ b/go/bazel.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -39,6 +40,10 @@ type TestingBazel struct {
 
 	// Path to the testing temp directory.
 	tmpDir string
+}
+
+func IsWindows() bool {
+	return runtime.GOOS == "windows"
 }
 
 // New instance of a TestingBazel will be created and the program will cd into
@@ -58,7 +63,11 @@ func New() (*TestingBazel, error) {
 	b := &TestingBazel{
 		tmpDir: dir,
 	}
-	if !b.setAndUnpackBazel(fmt.Sprintf("build_bazel_bazel_%s/bazel", strings.Replace(BazelVersion, ".", "_", -1))) {
+	suffix := ""
+	if IsWindows() {
+		suffix = ".exe"
+	}
+	if !b.setAndUnpackBazel(fmt.Sprintf("build_bazel_bazel_%s/bazel%s", strings.Replace(BazelVersion, ".", "_", -1), suffix)) {
 		return nil, errors.New("Unable to find Bazel")
 	}
 

--- a/java/build/bazel/tests/integration/BUILD
+++ b/java/build/bazel/tests/integration/BUILD
@@ -8,6 +8,7 @@ java_library(
         "Command.java",
         "RepositoryCache.java",
         "WorkspaceDriver.java",
+        "OS.java",
     ],
     visibility = ["//visibility:public"],
 )

--- a/java/build/bazel/tests/integration/OS.java
+++ b/java/build/bazel/tests/integration/OS.java
@@ -1,0 +1,82 @@
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package build.bazel.tests.integration;
+
+import java.util.EnumSet;
+
+/**
+ * Detects the running operating system and returns a describing enum value.
+ */
+public enum OS {
+  DARWIN("osx", "Mac OS X"),
+  FREEBSD("freebsd", "FreeBSD"),
+  LINUX("linux", "Linux"),
+  WINDOWS("windows", "Windows"),
+  UNKNOWN("unknown", "");
+
+  private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, LINUX);
+
+  private final String canonicalName;
+  private final String detectionName;
+
+  OS(String canonicalName, String detectionName) {
+    this.canonicalName = canonicalName;
+    this.detectionName = detectionName;
+  }
+
+  public String getCanonicalName() {
+    return canonicalName;
+  }
+
+  @Override
+  public String toString() {
+    return getCanonicalName();
+  }
+
+  private static final OS HOST_SYSTEM = determineCurrentOs();
+
+  /**
+   * The current operating system.
+   */
+  public static OS getCurrent() {
+    return HOST_SYSTEM;
+  }
+
+  public static boolean isPosixCompatible() {
+    return POSIX_COMPATIBLE.contains(getCurrent());
+  }
+
+  public static String getVersion() {
+    return System.getProperty("os.version");
+  }
+
+  // We inject a the OS name through blaze.os, so we can have
+  // some coverage for Windows specific code on Linux.
+  private static OS determineCurrentOs() {
+    String osName = System.getProperty("os.name");
+
+    if (osName == null) {
+      return OS.UNKNOWN;
+    }
+
+    for (OS os : OS.values()) {
+      // Windows have many names, all starting with "Windows".
+      if (osName.startsWith(os.detectionName)) {
+        return os;
+      }
+    }
+
+    return OS.UNKNOWN;
+  }
+}

--- a/java/build/bazel/tests/integration/RepositoryCache.java
+++ b/java/build/bazel/tests/integration/RepositoryCache.java
@@ -109,19 +109,23 @@ public class RepositoryCache {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                 throws IOException {
               if (file.getFileSystem().isReadOnly()) return FileVisitResult.CONTINUE;
-              Set<PosixFilePermission> perms = new HashSet<>();
-              perms.add(PosixFilePermission.OWNER_READ);
-              Files.setPosixFilePermissions(file, perms);
+              if (file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Set<PosixFilePermission> perms = new HashSet<>();
+                perms.add(PosixFilePermission.OWNER_READ);
+                Files.setPosixFilePermissions(file, perms);
+              }
               return FileVisitResult.CONTINUE;
             }
 
             @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc)
                 throws IOException {
-              Set<PosixFilePermission> perms = new HashSet<>();
-              perms.add(PosixFilePermission.OWNER_READ);
-              perms.add(PosixFilePermission.OWNER_EXECUTE); // For 'ls'
-              Files.setPosixFilePermissions(dir, perms);
+              if (dir.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Set<PosixFilePermission> perms = new HashSet<>();
+                perms.add(PosixFilePermission.OWNER_READ);
+                perms.add(PosixFilePermission.OWNER_EXECUTE); // For 'ls'
+                Files.setPosixFilePermissions(dir, perms);
+              }
               return FileVisitResult.CONTINUE;
             }
           });

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -70,7 +70,10 @@ public class WorkspaceDriver {
   }
 
   private static void setupTmp() throws IOException {
-    String environmentTempDirectory = System.getenv("TEST_TMPDIR");
+    // We have to use a shorted output user root on Windows, otherwise we get
+    // a "current working directory is too long" error, so use TMP instead of "TEST_TMPDIR"
+    String environmentTempDirectory =
+      OS.getCurrent() == OS.WINDOWS ? System.getenv("TMP") : System.getenv("TEST_TMPDIR");
     if (environmentTempDirectory == null) {
       tmp = Files.createTempDirectory("e4b-tests");
       tmp.toFile().deleteOnExit();

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -71,9 +71,10 @@ public class WorkspaceDriver {
 
   private static void setupTmp() throws IOException {
     // We have to use a shorted output user root on Windows, otherwise we get
-    // a "current working directory is too long" error, so use TMP instead of "TEST_TMPDIR"
+    // a "current working directory is too long" error,
+    // so use a generated temp directory instead of "TEST_TMPDIR".
     String environmentTempDirectory =
-      OS.getCurrent() == OS.WINDOWS ? System.getenv("TMP") : System.getenv("TEST_TMPDIR");
+      OS.getCurrent() == OS.WINDOWS ? null : System.getenv("TEST_TMPDIR");
     if (environmentTempDirectory == null) {
       tmp = Files.createTempDirectory("e4b-tests");
       tmp.toFile().deleteOnExit();

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -66,7 +66,7 @@ public class WorkspaceDriver {
         repositoryCache.put(Paths.get(dep));
       }
     }
-    repositoryCache.freeze();
+    // repositoryCache.freeze();
   }
 
   private static void setupTmp() throws IOException {

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -76,7 +76,8 @@ public class WorkspaceDriver {
     String environmentTempDirectory =
       OS.getCurrent() == OS.WINDOWS ? null : System.getenv("TEST_TMPDIR");
     if (environmentTempDirectory == null) {
-      tmp = Files.createTempDirectory("e4b-tests");
+      Path tmpPath = Paths.get(System.getenv("TMP"));
+      tmp = Files.createTempDirectory(tmpPath, "e4b-tests");
       tmp.toFile().deleteOnExit();
     } else {
       tmp = Paths.get(environmentTempDirectory);

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -11,6 +11,9 @@ bazel_java_integration_test(
         "//java/build/bazel/tests/integration",
         "@com_google_truth//jar",
     ],
+    # We had to disable this test on Windows because it will fail due to running Bazel
+    # from a path longer than 256 charactors.
+    tags = ["no_windows"],
 )
 
 bazel_java_integration_test(

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -11,9 +11,6 @@ bazel_java_integration_test(
         "//java/build/bazel/tests/integration",
         "@com_google_truth//jar",
     ],
-    # We had to disable this test on Windows because it will fail due to running Bazel
-    # from a path longer than 256 charactors.
-    tags = ["no_windows"],
 )
 
 bazel_java_integration_test(

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -1,4 +1,6 @@
 load("//:bazel_integration_test.bzl", "bazel_java_integration_test")
+load("//tools:common.bzl", "GET_LATEST_BAZEL_VERSIONS")
+load("//tools:common.bzl", "BAZEL_VERSIONS")
 
 bazel_java_integration_test(
     name = "BazelBaseTestCaseTest",
@@ -10,6 +12,31 @@ bazel_java_integration_test(
     deps = [
         "//java/build/bazel/tests/integration",
         "@com_google_truth//jar",
+    ],
+    # Some older version doesn't support --enable_runfiles on Windows
+    tags = ["no_windows"],
+)
+
+# We only run BazelBaseTestCaseTest with Bazel version >= 0.21.0,
+# where --enable_runfiles is supported.
+# Unfortunately, versions attribute doesn't support select, so we have
+# to create a separate target for Windows.
+bazel_java_integration_test(
+    name = "BazelBaseTestCaseTest_windows",
+    srcs = ["BazelBaseTestCaseTest.java"],
+    data = [
+        "//:all_bzl",
+    ],
+    jvm_flags = ["-Dfoo.bar=true"],
+    versions = GET_LATEST_BAZEL_VERSIONS(),
+    deps = [
+        "//java/build/bazel/tests/integration",
+        "@com_google_truth//jar",
+    ],
+    # No need to rerun the same tests on Linux and macOs
+    tags = [
+        "no_macos",
+        "no_linux",
     ],
 )
 

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -43,8 +43,5 @@ bazel_java_integration_test(
         "@test_archive",
         "@test_archive2",
     ],
-    # Ensure that there could be no network fetch in sandboxing.  This tag is a Bazel
-    # built-in, it is important to keep it.
-    tags = ["block-network"],
     deps = ["//java/build/bazel/tests/integration"],
 )

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -45,6 +45,9 @@ bazel_java_integration_test(
     ],
     # Ensure that there could be no network fetch in sandboxing.  This tag is a Bazel
     # built-in, it is important to keep it.
-    tags = ["block-network"],
+    tags = [
+        "block-network",
+        "exclusive",
+    ],
     deps = ["//java/build/bazel/tests/integration"],
 )

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -45,9 +45,6 @@ bazel_java_integration_test(
     ],
     # Ensure that there could be no network fetch in sandboxing.  This tag is a Bazel
     # built-in, it is important to keep it.
-    tags = [
-        "block-network",
-        "exclusive",
-    ],
+    tags = ["block-network"],
     deps = ["//java/build/bazel/tests/integration"],
 )

--- a/javatests/build/bazel/tests/integration/BUILD
+++ b/javatests/build/bazel/tests/integration/BUILD
@@ -1,28 +1,10 @@
 load("//:bazel_integration_test.bzl", "bazel_java_integration_test")
 load("//tools:common.bzl", "GET_LATEST_BAZEL_VERSIONS")
-load("//tools:common.bzl", "BAZEL_VERSIONS")
-
-bazel_java_integration_test(
-    name = "BazelBaseTestCaseTest",
-    srcs = ["BazelBaseTestCaseTest.java"],
-    data = [
-        "//:all_bzl",
-    ],
-    jvm_flags = ["-Dfoo.bar=true"],
-    deps = [
-        "//java/build/bazel/tests/integration",
-        "@com_google_truth//jar",
-    ],
-    # Some older version doesn't support --enable_runfiles on Windows
-    tags = ["no_windows"],
-)
 
 # We only run BazelBaseTestCaseTest with Bazel version >= 0.21.0,
 # where --enable_runfiles is supported.
-# Unfortunately, versions attribute doesn't support select, so we have
-# to create a separate target for Windows.
 bazel_java_integration_test(
-    name = "BazelBaseTestCaseTest_windows",
+    name = "BazelBaseTestCaseTest",
     srcs = ["BazelBaseTestCaseTest.java"],
     data = [
         "//:all_bzl",
@@ -32,11 +14,6 @@ bazel_java_integration_test(
     deps = [
         "//java/build/bazel/tests/integration",
         "@com_google_truth//jar",
-    ],
-    # No need to rerun the same tests on Linux and macOs
-    tags = [
-        "no_macos",
-        "no_linux",
     ],
 )
 

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -44,8 +44,9 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
     driver.scratchFile("foo/BUILD", "sh_test(name = \"bar\",\n" + "srcs = [\"bar.sh\"])");
     driver.scratchExecutableFile("foo/bar.sh", "echo \"in bar\"");
 
+    // --enable_runfiles has no effect on Linux and macOS, but it enables runfiles symlink tree on Windows.
     BazelCommand cmd =
-        driver.bazel("run", "bar").inWorkingDirectory(Paths.get("foo")).mustRunSuccessfully();
+        driver.bazel("run", "bar", "--enable_runfiles").inWorkingDirectory(Paths.get("foo")).mustRunSuccessfully();
     assertThat(cmd.outputLines()).contains("in bar");
   }
 
@@ -53,8 +54,8 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
   public void testTestSuiteExists() throws Exception {
     loadIntegrationTestRuleIntoWorkspace();
     setupPassingTest("IntegrationTestSuiteTest");
-
-    driver.bazel("test", "//:IntegrationTestSuiteTest").mustRunSuccessfully();
+    // --enable_runfiles has no effect on Linux and macOS, but it enables runfiles symlink tree on Windows.
+    driver.bazel("test", "//:IntegrationTestSuiteTest", "--enable_runfiles").mustRunSuccessfully();
   }
 
   @Test

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
@@ -52,7 +52,7 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
 
   @Test
   public void testRunWithArguments() throws Exception {
-    driver.scratchFile("BUILD.bazel", shTest("test_me"));
+    driver.scratchFile("BUILD.bazel", shBinary("test_me"));
     driver.scratchExecutableFile("test_me.sh", shellTestingArguments("hello", "world"));
     driver.bazel("run", "//:test_me", "--", "hello", "world").mustRunSuccessfully();
   }
@@ -126,8 +126,7 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
         "    licenses = [\"notice\"],  # The MIT License",
         "    jar_sha256 = \"457877c79e038f390557db5f8e92c4436fb4f4b3ba63f28bc228500fee080193\",",
         "    jar_urls = [",
-        "        \"http://maven.ibiblio.org/maven2/net/sf/jopt-simple/jopt-simple/5.0.2/jopt-simple-5.0.2.jar\",",
-        "        \"http://repo1.maven.org/maven2/net/sf/jopt-simple/jopt-simple/5.0.2/jopt-simple-5.0.2.jar\",",
+        "        \"http://a.host.does.not.exist/jopt-simple-5.0.2.jar\",",
         "    ],",
         ")");
 
@@ -198,6 +197,11 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
   private static List<String> shTest(String name) {
     return Arrays.asList(
         "sh_test(", "  name = '" + name + "',", "  srcs = ['" + name + ".sh'],", ")");
+  }
+
+  private static List<String> shBinary(String name) {
+    return Arrays.asList(
+        "sh_binary(", "  name = '" + name + "',", "  srcs = ['" + name + ".sh'],", ")");
   }
 
   private static List<String> passingTestNamed(String name, String... additionalImports) {

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
@@ -150,7 +150,8 @@ public class WorkspaceDriverTest {
   }
 
   private Optional<Path> findPath(List<Path> paths, String path) {
-    return paths.stream().filter(x -> x.toString().endsWith(path)).findFirst();
+    final String path_platform = (OS.getCurrent() == OS.WINDOWS) ? path.replace("/", "\\") : path;
+    return paths.stream().filter(x -> x.toString().endsWith(path_platform)).findFirst();
   }
 
   private String jarNameAccordingToCurrentBazelVersion() {

--- a/tools/bazel_hash_dict.bzl
+++ b/tools/bazel_hash_dict.bzl
@@ -21,9 +21,9 @@ BAZEL_HASH_DICT = {
         "linux-x86_64": "feedbe02c81142ed95ef8d380472f0a0d88e1b9a4b1fb6e21728701032b68e02",
         "windows-x86_64": "ba6ad8931f1c82095a1194976f01adfafd881ee69fc69665334104c661800b4b",
     },
-    "0.23.2": {
-        "darwin-x86_64": "53fa727fd0bcce3e1953eef2eddd6b4c6f959cb34cb453f57787fd55874b6bc3",
-        "linux-x86_64": "5e77a0c06b45b12126e51a5fab13c89dfe6a356f86e1d27299dfac8e8746a7e9",
-        "windows-x86_64": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe",
-    },
+    # "0.23.2": {
+    #     "darwin-x86_64": "53fa727fd0bcce3e1953eef2eddd6b4c6f959cb34cb453f57787fd55874b6bc3",
+    #     "linux-x86_64": "5e77a0c06b45b12126e51a5fab13c89dfe6a356f86e1d27299dfac8e8746a7e9",
+    #     "windows-x86_64": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe",
+    # },
 }

--- a/tools/bazel_hash_dict.bzl
+++ b/tools/bazel_hash_dict.bzl
@@ -21,9 +21,19 @@ BAZEL_HASH_DICT = {
         "linux-x86_64": "feedbe02c81142ed95ef8d380472f0a0d88e1b9a4b1fb6e21728701032b68e02",
         "windows-x86_64": "ba6ad8931f1c82095a1194976f01adfafd881ee69fc69665334104c661800b4b",
     },
-    # "0.23.2": {
-    #     "darwin-x86_64": "53fa727fd0bcce3e1953eef2eddd6b4c6f959cb34cb453f57787fd55874b6bc3",
-    #     "linux-x86_64": "5e77a0c06b45b12126e51a5fab13c89dfe6a356f86e1d27299dfac8e8746a7e9",
-    #     "windows-x86_64": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe",
-    # },
+    "0.21.0": {
+        "darwin-x86_64": "5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc",
+        "linux-x86_64": "328d5fa87a61e1f6e674a8f88c5ae54b8987eaf5a6c944257600c5029c8feef8",
+        "windows-x86_64": "eb7db007a055fcdc7e595ddf8ee49de43ba5ac578c516496430a05aab7765877",
+    },
+    "0.22.0": {
+        "darwin-x86_64": "adae5bbc3bf2b9b60d460d8ea2c65da1a6edd75b242439dfc49d001272548d13",
+        "linux-x86_64": "6d85f9fd6671ec5ffa8c78d150fe6c8da50874cfa8aa1900672dfd93e9989cb0",
+        "windows-x86_64": "ce9cb6200ca7daffe9e59c82632caf9afa1b6e9adaa253a50c0e4ef711bcbb5c",
+    },
+    "0.23.2": {
+        "darwin-x86_64": "53fa727fd0bcce3e1953eef2eddd6b4c6f959cb34cb453f57787fd55874b6bc3",
+        "linux-x86_64": "5e77a0c06b45b12126e51a5fab13c89dfe6a356f86e1d27299dfac8e8746a7e9",
+        "windows-x86_64": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe",
+    },
 }

--- a/tools/bazel_hash_dict.bzl
+++ b/tools/bazel_hash_dict.bzl
@@ -4,17 +4,26 @@ BAZEL_HASH_DICT = {
     "0.15.2": {
         "darwin-x86_64": "84ee271274e7c8904a48f7894fe0569174d162c7428a19dda57fc6a6c95c628b",
         "linux-x86_64": "13eae0f09565cf17fc1c9ce1053b9eac14c11e726a2215a79ebaf5bdbf435241",
+        "windows-x86_64": "37b1eb9b782c4ca89f5c5951144f7b953341bdb7e3d2c10f60e36f82a872559d",
     },
     "0.16.0": {
         "darwin-x86_64": "bb4720c027a991643be7dabee5c96a84c3776d6e2da92bf65df012a7cec15569",
         "linux-x86_64": "bdef5499ea21baa69e707391b463105b32c4a2fbf1ab045da53f4023c1a033be",
+        "windows-x86_64": "01787fc5a71a1315a1369bf81db79f8787ecaf542ed6958791f584143cd91129",
     },
     "0.16.1": {
         "darwin-x86_64": "07d5c753738c7186117168770f525b59c39b24103f714be2ffcaadd8e2c53a78",
         "linux-x86_64": "17ab70344645359fd4178002f367885e9019ae7507c9c1ade8220f3628383444",
+        "windows-x86_64": "47f9a7f70801f731727412a8b80ab6b350e9302f61b4d70dee8d9479647d7917",
     },
     "0.17.1": {
         "darwin-x86_64": "6a75339b042ed0bc8ad67f017395e9032f253b241190e3050ba55e4255fde2d8",
         "linux-x86_64": "feedbe02c81142ed95ef8d380472f0a0d88e1b9a4b1fb6e21728701032b68e02",
+        "windows-x86_64": "ba6ad8931f1c82095a1194976f01adfafd881ee69fc69665334104c661800b4b",
+    },
+    "0.23.2": {
+        "darwin-x86_64": "53fa727fd0bcce3e1953eef2eddd6b4c6f959cb34cb453f57787fd55874b6bc3",
+        "linux-x86_64": "5e77a0c06b45b12126e51a5fab13c89dfe6a356f86e1d27299dfac8e8746a7e9",
+        "windows-x86_64": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe",
     },
 }

--- a/tools/repositories.bzl
+++ b/tools/repositories.bzl
@@ -15,17 +15,34 @@
 load("//tools:bazel_hash_dict.bzl", "BAZEL_HASH_DICT")
 load(":common.bzl", "BAZEL_VERSIONS")
 
-_BAZEL_BINARY_PACKAGE = "http://releases.bazel.build/{version}/release/bazel-{version}-installer-{platform}.sh"
+_BAZEL_BINARY_PACKAGE = "http://releases.bazel.build/{version}/release/bazel-{version}{installer}-{platform}.{extension}"
 
 def _get_platform_name(rctx):
   os_name = rctx.os.name.lower()
-  # We default on linux-x86_64 because we only support 2 platforms
-  return "darwin-x86_64" if os_name.startswith("mac os") else "linux-x86_64"
+
+  if os_name.startswith("mac os"):
+    return "darwin-x86_64"
+  if os_name.startswith("windows"):
+    return "windows-x86_64"
+
+  # We default on linux-x86_64 because we only support 3 platforms
+  return "linux-x86_64"
+
+def _is_windows(rctx):
+  return _get_platform_name(rctx).startswith("windows")
 
 def _get_installer(rctx):
   platform = _get_platform_name(rctx)
   version = rctx.attr.version
-  url = _BAZEL_BINARY_PACKAGE.format(version = version, platform = platform)
+
+  if _is_windows(rctx):
+    extension = "zip"
+    installer = ""
+  else:
+    extension = "sh"
+    installer = "-installer"
+
+  url = _BAZEL_BINARY_PACKAGE.format(version=version, installer=installer, platform=platform, extension=extension)
   args = {"url": url, "type": "zip"}
   if version in BAZEL_HASH_DICT and platform in BAZEL_HASH_DICT[version]:
     args["sha256"] = BAZEL_HASH_DICT[version][platform]
@@ -37,7 +54,10 @@ def _bazel_repository_impl(rctx):
   rctx.file("BUILD", """
 filegroup(
   name = "bazel_binary",
-  srcs = ["bazel-real","bazel"],
+  srcs = select({
+    "@bazel_tools//src/conditions:windows" : ["bazel.exe"],
+    "//conditions:default": ["bazel-real","bazel"],
+  }),
   visibility = ["//visibility:public"])""")
 
 bazel_binary = repository_rule(


### PR DESCRIPTION
Inspired by https://github.com/bazelbuild/bazel-integration-testing/pull/96, I also gave it a try.
I enabled all tests but `BazelBaseTestCaseTest` because it tries to run Bazel from a directory path longer than 260 characters, which caused the following error:
```
Executing tests from //:IntegrationTestSuiteTest/bazel0.23.2
-----------------------------------------------------------------------------
Error: Current working directory has a path longer than allowed for a
Win32 working directory.
Can't start native Windows application from here.

external/bazel_tools/tools/test/test-setup.sh: line 232: C:/src/tmp/l7b3czla/execroot/build_bazel_integration_testing/_tmp/b8fc8754c3be87e0fe08dc8ef9e1fd51/ajlaysar/execroot/build_bazel_integration_testing/bazel-out/x64_windows-fastbuild/bin/IntegrationTestSuiteTest/bazel0.23.2.exe: File name too long
/c/src/tmp/l7b3czla/execroot/build_bazel_integration_testing/_tmp/b8fc8754c3be87e0fe08dc8ef9e1fd51/ajlaysar/execroot/build_bazel_integration_testing/bazel-out/x64_windows-fastbuild/testlogs/IntegrationTestSuiteTest/bazel0.23.2/test.log (END)
```
@laszlocsomor Does the native test wrapper supports running Bazel from a long path? Maybe it could help fix this issue.

Another test case `testRepositoryCacheIsFrozen` in `WorkspaceDriverIntegrationTest.java` depends on the `WorkspaceDriver.freeze()`. The `freeze()` function doesn't work on Windows, and there is basically no way to prevent other process writing to a directory. So I cannot find any other way to freeze the cache. I worked around this by changing the url to a non-existing host which caused a "Unknown host" error to be caught. @ittaiz @hchauvin Is this ok with you?

