### PR TITLE
Disable tests on ubuntu1804 that don't work with JDK11

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,28 +2,31 @@
 platforms:
   ubuntu1604:
     build_targets:
-    - "..."
+      - "//..."
     test_targets:
-    - "..."
+      - "//..."
   ubuntu1804:
     build_targets:
-    - "..."
+      - "//..."
     test_targets:
-    - "..."
+      - "--"
+      - "//..."
+      - "-//javatests/build/bazel/tests/integration:WorkspaceDriverIntegrationTest/bazel0.15.2"
+      - "-//javatests/build/bazel/tests/integration:WorkspaceDriverIntegrationTest/bazel0.16.0"
   macos:
     build_targets:
-    - "..."
+      - "//..."
     test_targets:
-    - "..."
+      - "//..."
   windows:
     build_targets:
-    - "..."
+      - "//..."
     build_flags:
-    - "--enable_runfiles"
+      - "--enable_runfiles"
     test_flags:
-    - "--enable_runfiles"
-    - "--test_tag_filters=-no_windows"
-    - "--test_env=JAVA_HOME" # For building Java binary inside test
-    - "--test_env=BAZEL_SH"  # Make sure Bazel binary inside test can find the correct Bash (MSYS2 instead of Git)
+      - "--enable_runfiles"
+      - "--test_tag_filters=-no_windows"
+      - "--test_env=JAVA_HOME" # For building Java binary inside test
+      - "--test_env=BAZEL_SH" # Make sure Bazel binary inside test can find the correct Bash (MSYS2 instead of Git)
     test_targets:
-    - "..."
+      - "//..."


### PR DESCRIPTION
I have migrated ubuntu1804 to use OpenJDK 11, because that's the default JDK for that distribution.

During the migration I noticed that you have tests that fail with OpenJDK 11, so I recommend to
disable them until they're fixed.

For your reference, here's the log: https://buildkite.com/bazel/bazel-integration-testing/builds/554#d64d47cf-3e61-4a9e-a075-7c62e7fae27d