### PR TITLE
global properties are private and accessible as method accessor

### DIFF
--- a/java/build/bazel/tests/integration/BazelBaseTestCase.java
+++ b/java/build/bazel/tests/integration/BazelBaseTestCase.java
@@ -15,7 +15,6 @@
 package build.bazel.tests.integration;
 
 import java.io.IOException;
-import java.util.Properties;
 import org.junit.Before;
 import org.junit.BeforeClass;
 

--- a/java/build/bazel/tests/integration/BazelBaseTestCase.java
+++ b/java/build/bazel/tests/integration/BazelBaseTestCase.java
@@ -23,14 +23,10 @@ import org.junit.BeforeClass;
 public abstract class BazelBaseTestCase {
 
   protected WorkspaceDriver driver = new WorkspaceDriver();
-  protected static Properties properties;
 
   @BeforeClass
   public static void setUpClass() throws IOException {
     WorkspaceDriver.setUpClass();
-    //Properties is Some after call to WorkspaceDriver#setupClass
-    //noinspection OptionalGetWithoutIsPresent
-    properties = WorkspaceDriver.globalBazelProperties().get();
   }
 
   @Before

--- a/java/build/bazel/tests/integration/BazelBaseTestCase.java
+++ b/java/build/bazel/tests/integration/BazelBaseTestCase.java
@@ -15,6 +15,7 @@
 package build.bazel.tests.integration;
 
 import java.io.IOException;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -22,10 +23,14 @@ import org.junit.BeforeClass;
 public abstract class BazelBaseTestCase {
 
   protected WorkspaceDriver driver = new WorkspaceDriver();
+  protected static Properties properties;
 
   @BeforeClass
   public static void setUpClass() throws IOException {
     WorkspaceDriver.setUpClass();
+    //Properties is Some after call to WorkspaceDriver#setupClass
+    //noinspection OptionalGetWithoutIsPresent
+    properties = WorkspaceDriver.globalBazelProperties().get();
   }
 
   @Before

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -37,8 +37,6 @@ public class WorkspaceDriver {
   private static Path tmp;
   private static Map<String, Path> bazelVersions;
   private static Path runfileDirectory = Paths.get(System.getenv("TEST_SRCDIR"));
-  // TODO: Don't have them as writable package-private when we have a better way
-  // to share configuration across the WorkspaceDriver instances.
   private static Properties properties;
 
   private Path currentBazel = null;

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -63,8 +63,9 @@ public class WorkspaceDriver {
     javaToolchain = javaToolchainFromProperties();
   }
 
-  public static Optional<Properties> globalBazelProperties() {
-    return Optional.ofNullable(properties);
+  public static Properties globalBazelProperties() {
+    return Optional.ofNullable(properties)
+        .orElseThrow(() -> new IllegalStateException("Need to call setupClass() before calling globalBazelProperties()"));
   }
   private static void setupRepositoryCache() throws IOException {
     String externalDeps = properties.getProperty("bazel.external.deps");

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,7 +39,7 @@ public class WorkspaceDriver {
   private static Path runfileDirectory = Paths.get(System.getenv("TEST_SRCDIR"));
   // TODO: Don't have them as writable package-private when we have a better way
   // to share configuration across the WorkspaceDriver instances.
-  @Deprecated static Properties properties;
+  private static Properties properties;
 
   private Path currentBazel = null;
 
@@ -64,6 +65,9 @@ public class WorkspaceDriver {
     javaToolchain = javaToolchainFromProperties();
   }
 
+  public static Optional<Properties> globalBazelProperties() {
+    return Optional.ofNullable(properties);
+  }
   private static void setupRepositoryCache() throws IOException {
     String externalDeps = properties.getProperty("bazel.external.deps");
     repositoryCache = new RepositoryCache(tmp.resolve("cache"));

--- a/java/build/bazel/tests/integration/WorkspaceDriver.java
+++ b/java/build/bazel/tests/integration/WorkspaceDriver.java
@@ -63,9 +63,12 @@ public class WorkspaceDriver {
     javaToolchain = javaToolchainFromProperties();
   }
 
-  public static Properties globalBazelProperties() {
-    return Optional.ofNullable(properties)
-        .orElseThrow(() -> new IllegalStateException("Need to call setupClass() before calling globalBazelProperties()"));
+  /**
+   * @return The global properties passed by the starlark rule.
+   * Will be null if setupClass wasn't called before calling globalBazelProperties()
+   */
+  static Properties globalBazelProperties() {
+    return properties;
   }
   private static void setupRepositoryCache() throws IOException {
     String externalDeps = properties.getProperty("bazel.external.deps");

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -36,7 +36,7 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
   public void testVersion() throws Exception {
     BazelCommand cmd = driver.bazel("info", "release").mustRunSuccessfully();
     assertThat(cmd.outputLines())
-        .contains("release " + properties.getProperty("bazel.version"));
+        .contains("release " + WorkspaceDriver.globalBazelProperties().getProperty("bazel.version"));
   }
 
   @Test

--- a/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
+++ b/javatests/build/bazel/tests/integration/BazelBaseTestCaseTest.java
@@ -36,7 +36,7 @@ public final class BazelBaseTestCaseTest extends BazelBaseTestCase {
   public void testVersion() throws Exception {
     BazelCommand cmd = driver.bazel("info", "release").mustRunSuccessfully();
     assertThat(cmd.outputLines())
-        .contains("release " + WorkspaceDriver.properties.getProperty("bazel.version"));
+        .contains("release " + properties.getProperty("bazel.version"));
   }
 
   @Test

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
@@ -14,16 +14,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class WorkspaceDriverTest {
   private WorkspaceDriver driver = new WorkspaceDriver();
+  private static Properties properties;
 
   @BeforeClass
   public static void setUpClass() throws IOException {
     WorkspaceDriver.setUpClass();
+    //Properties is Some after call to WorkspaceDriver#setupClass
+    //noinspection OptionalGetWithoutIsPresent
+    properties = WorkspaceDriver.globalBazelProperties().get();
   }
 
   @Before
@@ -155,7 +160,7 @@ public class WorkspaceDriverTest {
   }
 
   private String jarNameAccordingToCurrentBazelVersion() {
-    return "bazel" + WorkspaceDriver.properties.getProperty("bazel.version") + ".jar";
+    return "bazel" + properties.getProperty("bazel.version") + ".jar";
   }
 
 }

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverTest.java
@@ -21,14 +21,10 @@ import org.junit.Test;
 
 public class WorkspaceDriverTest {
   private WorkspaceDriver driver = new WorkspaceDriver();
-  private static Properties properties;
 
   @BeforeClass
   public static void setUpClass() throws IOException {
     WorkspaceDriver.setUpClass();
-    //Properties is Some after call to WorkspaceDriver#setupClass
-    //noinspection OptionalGetWithoutIsPresent
-    properties = WorkspaceDriver.globalBazelProperties().get();
   }
 
   @Before
@@ -160,7 +156,7 @@ public class WorkspaceDriverTest {
   }
 
   private String jarNameAccordingToCurrentBazelVersion() {
-    return "bazel" + properties.getProperty("bazel.version") + ".jar";
+    return "bazel" + WorkspaceDriver.globalBazelProperties().getProperty("bazel.version") + ".jar";
   }
 
 }


### PR DESCRIPTION
removes this irritating deprecated usage warning that we added so that people won't use our global mutable state