### PR TITLE
ease test troubleshooting out of the box

### DIFF
--- a/java/build/bazel/tests/integration/BazelCommand.java
+++ b/java/build/bazel/tests/integration/BazelCommand.java
@@ -175,7 +175,7 @@ public class BazelCommand {
      * and returns an object to inspect the invocation result.
      */
     public BazelCommand mustRunAndReturnExitCode(int exitCode) throws IOException, InterruptedException {
-      BazelCommand cmd = run();
+      BazelCommand cmd = runQuietly();
       if (cmd.exitCode() != exitCode) {
         throw new RuntimeException(cmd + "==> exit code != " + exitCode);
       }

--- a/java/build/bazel/tests/integration/BazelCommand.java
+++ b/java/build/bazel/tests/integration/BazelCommand.java
@@ -156,8 +156,16 @@ public class BazelCommand {
           .build();
     }
 
-    /** Runs the command and returns an object to inspect the invocation result. */
+    /** Runs the command, prints its output to console and
+     * returns an object to inspect the invocation result. */
     public BazelCommand run() throws IOException, InterruptedException {
+      BazelCommand command = runQuietly();
+      System.out.println(command.toString());
+      return command;
+    }
+
+    /** Runs the command and returns an object to inspect the invocation result. */
+    public BazelCommand runQuietly() throws IOException, InterruptedException {
       Command cmd = build();
       return new BazelCommand(cmd, args, cmd.run(), driver);
     }

--- a/java/build/bazel/tests/integration/BazelCommand.java
+++ b/java/build/bazel/tests/integration/BazelCommand.java
@@ -158,14 +158,14 @@ public class BazelCommand {
 
     /** Runs the command, prints its output to console and
      * returns an object to inspect the invocation result. */
-    public BazelCommand run() throws IOException, InterruptedException {
-      BazelCommand command = runQuietly();
+    public BazelCommand runVerbose() throws IOException, InterruptedException {
+      BazelCommand command = run();
       System.out.println(command.toString());
       return command;
     }
 
     /** Runs the command and returns an object to inspect the invocation result. */
-    public BazelCommand runQuietly() throws IOException, InterruptedException {
+    public BazelCommand run() throws IOException, InterruptedException {
       Command cmd = build();
       return new BazelCommand(cmd, args, cmd.run(), driver);
     }
@@ -175,7 +175,7 @@ public class BazelCommand {
      * and returns an object to inspect the invocation result.
      */
     public BazelCommand mustRunAndReturnExitCode(int exitCode) throws IOException, InterruptedException {
-      BazelCommand cmd = runQuietly();
+      BazelCommand cmd = run();
       if (cmd.exitCode() != exitCode) {
         throw new RuntimeException(cmd + "==> exit code != " + exitCode);
       }


### PR DESCRIPTION
Global context:
I'm trying to use this library on a new repo and I'm stumbling on some caveats which we solved in our existing repo by wrapping this library.
I'm trying now to avoid this and actually upstream the fixes here.

Specific context:
Without this whenever a test fails it's very hard to understand what's going on without adding interim debug prints (interim because they are ugly) or debugging the test.

run command prints the toString of BazelCommand
added an opt-out runQuietly method

@or-shachar and @anchlovi I'd appreciate your review
