### PR TITLE
Update @bazel_toolchains to latest release.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Remote execution infra
 # Required configuration for remote build execution
-bazel_toolchains_version="be10bee3010494721f08a0fccd7f57411a1e773e"
-bazel_toolchains_sha256="5962fe677a43226c409316fcb321d668fc4b7fa97cb1f9ef45e7dc2676097b26"
+bazel_toolchains_version="0.26.1"
+bazel_toolchains_sha256="c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d"
 http_archive(
          name = "bazel_toolchains",
          urls = [
@@ -135,8 +135,8 @@ bazel_external_dependency_archive(
 bazel_external_dependency_archive(
    name = "bazel_toolchains_test",
    srcs = {
-       "5962fe677a43226c409316fcb321d668fc4b7fa97cb1f9ef45e7dc2676097b26": [
-           "https://github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
+       "c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d": [
+           "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
        ],
    }
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,14 @@ http_archive(
          sha256 = bazel_toolchains_sha256,
 )
 
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+# Creates toolchain configuration for remote execution with BuildKite CI
+# for rbe_ubuntu1604
+rbe_autoconfig(
+    name = "buildkite_config",
+)
+
 ## Sanity checks
 
 git_repository(

--- a/javatests/build/bazel/tests/integration/RBEExampleTest.java
+++ b/javatests/build/bazel/tests/integration/RBEExampleTest.java
@@ -1,7 +1,6 @@
 package build.bazel.tests.integration;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -18,28 +17,27 @@ public class RBEExampleTest extends BazelBaseTestCase {
     writeWorkspaceFileWithBazelToolchains();
     remoteCompatibleBazelRcFile();
 
-    driver
-        .bazel("test", "//:" + testName)
-        .mustRunSuccessfully();
+    driver.bazel("test", "//:" + testName).mustRunSuccessfully();
   }
 
   private void writeWorkspaceFileWithBazelToolchains() throws IOException {
-    driver.scratchFile("WORKSPACE",
+    driver.scratchFile(
+        "WORKSPACE",
         "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")",
-      "http_archive(",
-      "             name = \"bazel_toolchains\",",
-      "             urls = [",
-      "               \"https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz\"",
-      "             ],",
-      "             strip_prefix = \"bazel-toolchains-be10bee3010494721f08a0fccd7f57411a1e773e\",",
-      "             sha256 = \"5962fe677a43226c409316fcb321d668fc4b7fa97cb1f9ef45e7dc2676097b26\",",
-      ")"
-        );
+        "http_archive(",
+        "    name = \"bazel_toolchains\",",
+        "    urls = [",
+        "        \"https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz\"",
+        "    ],",
+        "    strip_prefix = \"bazel-toolchains-0.26.1\",",
+        "    sha256 = \"c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d\",",
+        ")");
   }
 
   private void writeToolchainsPlatformTarget() throws IOException {
-    driver.scratchFile("toolchains/BUILD.bazel",
-      "package(default_visibility = [\"//visibility:public\"])",
+    driver.scratchFile(
+        "toolchains/BUILD.bazel",
+        "package(default_visibility = [\"//visibility:public\"])",
         "platform(",
         "    name = \"rbe_ubuntu1604\",",
         "    constraint_values = [",
@@ -53,16 +51,14 @@ public class RBEExampleTest extends BazelBaseTestCase {
   }
 
   private void remoteCompatibleBazelRcFile() throws IOException {
-    driver.scratchFile(".bazelrc",
-        remoteCompatibleToolchainFlags());
+    driver.scratchFile(".bazelrc", remoteCompatibleToolchainFlags());
   }
 
   private static List<String> remoteCompatibleToolchainFlags() {
-     return Arrays.asList(
-         "build --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/default:toolchain",
-         "build --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/cpp:cc-toolchain-clang-x86_64-default",
-         "build --extra_execution_platforms=//toolchains:rbe_ubuntu1604"
-     );
+    return Arrays.asList(
+        "build --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/default:toolchain",
+        "build --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/cpp:cc-toolchain-clang-x86_64-default",
+        "build --extra_execution_platforms=//toolchains:rbe_ubuntu1604");
   }
 
   private List<String> helloWorldShellScript() {
@@ -73,5 +69,4 @@ public class RBEExampleTest extends BazelBaseTestCase {
     return Arrays.asList(
         "sh_test(", "  name = '" + name + "',", "  srcs = ['" + name + ".sh'],", ")");
   }
-
 }


### PR DESCRIPTION
This is required to support RBE toolchain auto-configuration, which is now used on Bazel's CI.

FYI @nlopezgi