### PR TITLE
Fix failed JVM ExampleTest

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -46,6 +46,7 @@ public class ExampleTest {
 
   @Test
   public void bazelFailure() throws Exception {
+    driver.scratchFile(".bazelrc", "build --test_output=all");
     driver.scratchFile("foo/BUILD", "sh_test(name = \"bar\",\n" + "srcs = [\"bar.sh\"])");
     driver.scratchExecutableFile("foo/bar.sh", "echo \"boom\"", "exit -1");
 
@@ -54,7 +55,7 @@ public class ExampleTest {
     assertNotEquals("bazel test return code", 0, cmd.exitCode());
     assertTrue(
         "stderr contains boom failure",
-        cmd.errorLines().stream().anyMatch(x -> x.contains("boom")));
+        cmd.outputLines().stream().anyMatch(x -> x.contains("boom")));
   }
 }
 ```  


### PR DESCRIPTION
It turns out https://github.com/bazelbuild/bazel-integration-testing/pull/152 didn't get the example test fully functioning. I can confirm this PR gets it working.

Test is failing because `echo "boom"` goes to test log. I don't see a clear way to read test log content. I got around it by specifying [--test_output](https://docs.bazel.build/versions/master/command-line-reference.html). It outputs test log contents to stdout.

It could also be
```
BazelCommand cmd = driver.bazel("test", "--test_output=all", "//foo:bar").run();
```