### PR TITLE
Migrate maven_jar to jvm_maven_import_external

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,16 +5,18 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Remote execution infra
 # Required configuration for remote build execution
-bazel_toolchains_version="0.26.1"
-bazel_toolchains_sha256="c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d"
+bazel_toolchains_version = "0.26.1"
+
+bazel_toolchains_sha256 = "c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d"
+
 http_archive(
-         name = "bazel_toolchains",
-         urls = [
-           "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/%s.tar.gz"%bazel_toolchains_version,
-           "https://github.com/bazelbuild/bazel-toolchains/archive/%s.tar.gz"%bazel_toolchains_version
-         ],
-         strip_prefix = "bazel-toolchains-%s"%bazel_toolchains_version,
-         sha256 = bazel_toolchains_sha256,
+    name = "bazel_toolchains",
+    sha256 = bazel_toolchains_sha256,
+    strip_prefix = "bazel-toolchains-%s" % bazel_toolchains_version,
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/%s.tar.gz" % bazel_toolchains_version,
+        "https://github.com/bazelbuild/bazel-toolchains/archive/%s.tar.gz" % bazel_toolchains_version,
+    ],
 )
 
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
@@ -66,14 +68,26 @@ py_library(
 
 ## Java
 
-maven_jar(
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
+jvm_maven_import_external(
     name = "com_google_truth",
     artifact = "com.google.truth:truth:jar:0.31",
+    artifact_sha256 = "abf21a12d26fbed5a1468f7f47699cc70c3f3832a7cc728b402880a3e5911963",
+    server_urls = [
+        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
+    ],
 )
 
-maven_jar(
+jvm_maven_import_external(
     name = "com_spotify_hamcrest_optional",
     artifact = "com.spotify:hamcrest-optional:jar:1.1.1",
+    artifact_sha256 = "8362a0a818c4fe41563841d3ef9411475e07dd43e65d1b89063eeefa237256ea",
+    server_urls = [
+        "https://jcenter.bintray.com/",
+        "https://repo1.maven.org/maven2",
+    ],
 )
 
 ## golang
@@ -96,7 +110,7 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -141,12 +155,12 @@ bazel_external_dependency_archive(
 )
 
 bazel_external_dependency_archive(
-   name = "bazel_toolchains_test",
-   srcs = {
-       "c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d": [
-           "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
-       ],
-   }
+    name = "bazel_toolchains_test",
+    srcs = {
+        "c6159396a571280c71d072a38147d43dcb44f78fc15976d0d47e6d0bf015458d": [
+            "https://github.com/bazelbuild/bazel-toolchains/archive/0.26.1.tar.gz",
+        ],
+    },
 )
 
 ## Your new language here!

--- a/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
+++ b/javatests/build/bazel/tests/integration/WorkspaceDriverIntegrationTest.java
@@ -174,7 +174,7 @@ public class WorkspaceDriverIntegrationTest extends BazelBaseTestCase {
   private void addExternalRepositoryFor(final String repoName, final String repoJarName)
       throws IOException {
     driver.copyFromRunfiles(
-        "build_bazel_integration_testing/external/" + repoName + "/jar/" + repoJarName,
+        "build_bazel_integration_testing/external/" + repoName + "/" + repoJarName,
         "external/" + repoName + "/jar/" + repoJarName);
     driver.scratchFile("external/" + repoName + "/WORKSPACE", "");
     driver.scratchFile(

--- a/tools/bazel_hash_dict.bzl
+++ b/tools/bazel_hash_dict.bzl
@@ -17,3 +17,4 @@ BAZEL_HASH_DICT = {
         "windows-x86_64": "a91c8c2b8d31709e74310e31d0a11ba237c4f4dcff7adc0e1102fbb66a489ffe",
     },
 }
+

--- a/tools/bazel_java_integration_test.bzl
+++ b/tools/bazel_java_integration_test.bzl
@@ -22,6 +22,8 @@ load(
     "bazel_binaries",
 )
 
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
 def _bazel_java_integration_test_properties_impl(ctx):
   java_runtime_info = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
   properties = [
@@ -157,18 +159,32 @@ def bazel_java_integration_test(
 def bazel_java_integration_test_deps(versions = BAZEL_VERSIONS):
   bazel_binaries(versions)
 
-  # TODO(dmarting): Use http_file and relies on a mirror instead of maven_jar
-  native.maven_jar(
+  jvm_maven_import_external(
       name = "com_google_guava",
       artifact = "com.google.guava:guava:jar:21.0",
+      artifact_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+      server_urls = [
+          "https://jcenter.bintray.com/",
+          "https://repo1.maven.org/maven2",
+      ],
   )
 
-  native.maven_jar(
+  jvm_maven_import_external(
       name = "org_hamcrest_core",
       artifact = "org.hamcrest:hamcrest-core:jar:1.3",
+      artifact_sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+      server_urls = [
+          "https://jcenter.bintray.com/",
+          "https://repo1.maven.org/maven2",
+      ],
   )
 
-  native.maven_jar(
+  jvm_maven_import_external(
       name = "org_junit",
       artifact = "junit:junit:jar:4.11",
+      artifact_sha256 = "90a8e1603eeca48e7e879f3afbc9560715322985f39a274f6f6070b43f9d06fe",
+      server_urls = [
+          "https://jcenter.bintray.com/",
+          "https://repo1.maven.org/maven2",
+      ],
   )


### PR DESCRIPTION
This prepares the repo for Bazel 2.0.